### PR TITLE
feat(models): add Pydantic models for error summary

### DIFF
--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -1,0 +1,174 @@
+Core API Usage
+==============
+
+This guide covers advanced usage of the FLUXNET Shuttle Library's core API, including the plugin system and error handling.
+
+Overview
+--------
+
+The FLUXNET Shuttle Library uses a plugin-based architecture where each FLUXNET network is implemented as a plugin. The core API provides direct access to these plugins and the orchestrator that coordinates them.
+
+Key Components
+~~~~~~~~~~~~~~
+
+- **FluxnetShuttle**: Main orchestrator that coordinates multiple network plugins
+- **NetworkPlugin**: Abstract base class for network-specific implementations
+- **PluginRegistry**: Manages plugin registration and instantiation
+- **ErrorCollectingIterator**: Async iterator that collects errors while continuing to yield results
+
+Using FluxnetShuttle
+--------------------
+
+The ``FluxnetShuttle`` class provides an interface for working with multiple network plugins simultaneously.
+
+Basic Usage
+~~~~~~~~~~~
+
+.. code-block:: python
+
+    from fluxnet_shuttle_lib.core.shuttle import FluxnetShuttle
+
+    # Create shuttle instance (automatically loads all registered plugins)
+    shuttle = FluxnetShuttle()
+
+    # Fetch data from all networks asynchronously
+    sites = []
+    for site in shuttle.get_all_sites():
+        sites.append(site)
+
+    # Access results
+    print(f"Retrieved {len(sites)} sites")
+
+Error Handling
+--------------
+
+The library provides comprehensive error handling with Pydantic models for type-safe error reporting.
+
+Programmatic Error Handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from fluxnet_shuttle_lib.core.shuttle import FluxnetShuttle
+
+    # Create shuttle instance
+    shuttle = FluxnetShuttle()
+
+    # Fetch data from all networks
+    sites = []
+    for site in shuttle.get_all_sites():
+        sites.append(site)
+
+    # Get error summary (returns Pydantic ErrorSummary model)
+    error_summary = shuttle.get_errors()
+
+    print(f"Total results: {error_summary.total_results}")
+    print(f"Total errors: {error_summary.total_errors}")
+
+    # Access detailed error information
+    for error in error_summary.errors:
+        print(f"Network: {error.network}")
+        print(f"Operation: {error.operation}")
+        print(f"Error: {error.error}")
+        print(f"Timestamp: {error.timestamp}")
+
+The `ErrorSummary` model includes:
+
+- `total_errors` (int): Total number of errors encountered
+- `total_results` (int): Total number of successful results retrieved
+- `errors` (List[PluginErrorDetail]): Detailed error information with network, operation, error message, and ISO timestamp
+
+Working with Individual Plugins
+--------------------------------
+
+You can also work with individual network plugins directly:
+
+.. code-block:: python
+
+    from fluxnet_shuttle_lib.core.registry import registry
+
+    # List all available plugins
+    plugin_names = registry.list_plugins()
+    print(f"Available plugins: {plugin_names}")  # ['ameriflux', 'icos',...]
+
+    # Create a plugin instance
+    ameriflux = registry.create_instance("ameriflux")
+
+    # Use the plugin (sync interface)
+    for site in ameriflux.get_sites():
+        print(f"AmeriFlux site: {site.site_id}")
+
+Plugin Discovery
+~~~~~~~~~~~~~~~~
+
+List all available plugins and create instances:
+
+.. code-block:: python
+
+    from fluxnet_shuttle_lib.core.registry import registry
+
+    # Get all registered plugin names
+    plugin_names = registry.list_plugins()
+    print(f"Available plugins: {plugin_names}")
+
+    # Create plugin instances and use them
+    for name in plugin_names:
+        plugin = registry.create_instance(name)
+        print(f"Plugin: {plugin.display_name}")
+
+Async/Sync Bridge
+-----------------
+
+The library provides both async and sync interfaces using decorators. Choose the appropriate interface based on your execution context.
+
+
+Synchronous Interface
+~~~~~~~~~~~~~~~~~~~~~
+
+For normal Python scripts and synchronous contexts, use regular for loops:
+
+.. code-block:: python
+
+    from fluxnet_shuttle_lib.core.shuttle import FluxnetShuttle
+
+    shuttle = FluxnetShuttle()
+
+    # Sync interface - works everywhere
+    for site in shuttle.get_all_sites():
+        print(f"Site: {site.site_id}")
+
+Asynchronous Interface
+~~~~~~~~~~~~~~~~~~~~~~
+
+Use the async interface when you're in an async context:
+
+- Inside async functions
+
+.. code-block:: python
+
+    import asyncio
+    from fluxnet_shuttle_lib.core.shuttle import FluxnetShuttle
+
+    async def fetch_sites():
+        shuttle = FluxnetShuttle()
+
+        # Async interface (preferred for concurrent operations)
+        sites = []
+        async for site in shuttle.get_all_sites():
+            sites.append(site)
+
+        return sites
+
+    # Run in async context
+    sites = asyncio.run(fetch_sites())
+
+In Jupyter notebooks or async frameworks, you can use async directly:
+
+.. code-block:: python
+
+    # In Jupyter notebook or FastAPI
+    shuttle = FluxnetShuttle()
+
+    async for site in shuttle.get_all_sites():
+        print(f"Site: {site.site_id}")
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,8 @@ Quick Start
     sites = ['US-ARc', 'IT-Niv']
     downloaded_files = download(site_ids=sites, runfile=csv_filename)
 
+For advanced usage with error handling and the developer API, see :doc:`developer_guide`.
+
 **Command Line Usage:**
 
 .. code-block:: bash
@@ -66,15 +68,16 @@ Quick Start
     # Run connectivity tests
     fluxnet-shuttle test
 
-API Reference
+Documentation
 =============
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-   modules
+   developer_guide
    cli
+   modules
 
 
 Indices and tables

--- a/src/fluxnet_shuttle_lib/core/shuttle.py
+++ b/src/fluxnet_shuttle_lib/core/shuttle.py
@@ -21,7 +21,7 @@ from typing import Any, AsyncGenerator, Dict, List, Optional
 from fluxnet_shuttle_lib.core.decorators import async_to_sync_generator
 from fluxnet_shuttle_lib.core.registry import ErrorCollectingIterator, registry
 
-from ..models import FluxnetDatasetMetadata
+from ..models import ErrorSummary, FluxnetDatasetMetadata
 from .config import ShuttleConfig
 
 logger = logging.getLogger(__name__)
@@ -90,20 +90,18 @@ class FluxnetShuttle:
         finally:
             # Log summary after iteration completes
             summary = error_collector.get_error_summary()
-            logger.info(
-                f"Completed get_all_sites: {summary['total_results']} results, " f"{summary['total_errors']} errors"
-            )
+            logger.info(f"Completed get_all_sites: {summary.total_results} results, " f"{summary.total_errors} errors")
 
-    def get_errors(self) -> Dict[str, Any]:
+    def get_errors(self) -> ErrorSummary:
         """
         Get collected errors from last operation.
 
         Returns:
-            Dict containing error summary information
+            ErrorSummary: Pydantic model containing error summary information
         """
         if self._last_error_collector:
             return self._last_error_collector.get_error_summary()
-        return {"total_errors": 0, "total_results": 0, "errors": []}
+        return ErrorSummary(total_errors=0, total_results=0, errors=[])
 
     def list_available_networks(self) -> List[str]:
         """

--- a/tests/test_core_shuttle.py
+++ b/tests/test_core_shuttle.py
@@ -113,7 +113,7 @@ class TestFluxnetShuttleIntegration:
 
         # Should have no errors since no plugins were attempted
         errors = shuttle.get_errors()
-        assert errors["total_errors"] == 0
+        assert errors.total_errors == 0
 
     @pytest.mark.asyncio
     async def test_error_collection(self):
@@ -150,9 +150,9 @@ class TestFluxnetShuttleIntegration:
 
         # Should have one error from the failing plugin
         errors = shuttle.get_errors()
-        assert errors["total_errors"] == 1
-        assert "failing" in errors["errors"][0]["network"]
-        assert "Mock plugin failure" in errors["errors"][0]["error"]
+        assert errors.total_errors == 1
+        assert "failing" in errors.errors[0].network
+        assert "Mock plugin failure" in errors.errors[0].error
 
     def test_sync_interface(self):
         """Test synchronous interface works correctly."""

--- a/tests/test_plugin_ameriflux.py
+++ b/tests/test_plugin_ameriflux.py
@@ -131,8 +131,7 @@ class TestAmeriFluxPlugin:
         assert sites[0].product_data.last_year == 2012  # Extracted from filename
 
     @patch("fluxnet_shuttle_lib.plugins.ameriflux.AmeriFluxPlugin._get_fluxnet_sites")
-    @patch("fluxnet_shuttle_lib.plugins.ameriflux.AmeriFluxPlugin._get_download_links")
-    def test_get_sites_api_failure(self, mock_get_links, mock_get_sites):
+    def test_get_sites_api_failure(self, mock_get_sites):
         """Test get_sites handles API failure gracefully."""
         mock_get_sites.side_effect = Exception("API failure")
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -88,9 +88,9 @@ class TestPluginRegistry:
 
         assert results == [{"id": 0, "name": "Site 0"}, {"id": 1, "name": "Site 1"}, {"id": 2, "name": "Site 2"}]
         errors = iterator.get_error_summary()
-        assert errors["total_errors"] == 0
-        assert errors["total_results"] == 3
-        assert errors["errors"] == []
+        assert errors.total_errors == 0
+        assert errors.total_results == 3
+        assert errors.errors == []
         # Test that calling get_errors_summary again returns the same result
         errors_again = iterator.get_error_summary()
         assert errors == errors_again
@@ -119,8 +119,8 @@ class TestPluginRegistry:
 
         assert results == [{"id": 0, "name": "Site 0"}]
         errors = iterator.get_error_summary()
-        assert errors["total_errors"] == 1
-        assert "Test error" in errors["errors"][0]["error"]
+        assert errors.total_errors == 1
+        assert "Test error" in errors.errors[0].error
         # Test that calling get_errors again returns the same result
         errors_again = iterator.get_error_summary()
         assert errors == errors_again
@@ -146,9 +146,9 @@ class TestPluginRegistry:
 
         assert results == []
         errors = iterator.get_error_summary()
-        assert errors["total_errors"] == 0
-        assert errors["total_results"] == 0
-        assert errors["errors"] == []
+        assert errors.total_errors == 0
+        assert errors.total_results == 0
+        assert errors.errors == []
         # Test that calling get_errors again returns the same result
         errors_again = iterator.get_error_summary()
         assert errors == errors_again
@@ -198,6 +198,6 @@ class TestPluginRegistry:
         assert results == []
         errors = iterator.get_error_summary()
         assert iterator.has_errors()
-        assert errors["total_errors"] == 4
-        assert errors["total_results"] == 0
-        assert len(errors["errors"]) == 4
+        assert errors.total_errors == 4
+        assert errors.total_results == 0
+        assert len(errors.errors) == 4


### PR DESCRIPTION
Replace plain dictionary error summaries with type-safe Pydantic models to improve error handling throughout the library.

Changes:
- Add PluginErrorDetail model with fields: network, operation, error, timestamp
- Add ErrorSummary model with fields: total_errors, total_results, errors list
- Update ErrorCollectingIterator.get_error_summary() to return ErrorSummary
- Update FluxnetShuttle.get_errors() to return ErrorSummary instead of dict
- Update all test assertions to use Pydantic model attributes instead of dict keys
- Add comprehensive error handling documentation to README.md
- Add error handling example to docs/index.rst with code samples

Benefits:
- Type safety: IDE autocomplete and type checking for error data
- Validation: Automatic validation of error data structure
- Documentation: Self-documenting error structure through model fields
- Consistency: Enforced error format across all plugins

Resolves #9