### PR TITLE
feat(icos): populate complete site metadata for ICOS network sites

### DIFF
--- a/tests/test_plugin_icos.py
+++ b/tests/test_plugin_icos.py
@@ -40,6 +40,7 @@ class TestICOSPlugin:
                         "station": {"value": "https://meta.icos-cp.eu/stations/US-ABC"},
                         "lat": {"value": "12.34"},
                         "lon": {"value": "56.78"},
+                        "ecosystemType": {"value": "http://meta.icos-cp.eu/ontologies/cpmeta/igbp_ENF"},
                         "timeStart": {"value": "2021-01-01T00:00:00Z"},
                         "timeEnd": {"value": "2021-12-31T23:59:59Z"},
                     }
@@ -60,9 +61,13 @@ class TestICOSPlugin:
         assert sites[0].site_info.network == "ICOS"
         assert sites[0].site_info.location_lat == 12.34
         assert sites[0].site_info.location_long == 56.78
+        assert sites[0].site_info.igbp == "ENF"
         assert sites[0].product_data.first_year == 2021
         assert sites[0].product_data.last_year == 2021
-        assert str(sites[0].product_data.download_link) == "https://meta.icos-cp.eu/objects/US-ABC"
+        # Pre-encoded URL format: %5B=[, %5D=], %22="
+        assert (
+            str(sites[0].product_data.download_link) == "https://data.icos-cp.eu/licence_accept?ids=%5B%22US-ABC%22%5D"
+        )
 
     @pytest.mark.asyncio
     @patch("fluxnet_shuttle_lib.plugins.icos.NetworkPlugin._session_request")
@@ -97,16 +102,20 @@ class TestICOSPlugin:
         assert sites[0].site_info.network == "ICOS"
         assert sites[0].site_info.location_lat == 12.34
         assert sites[0].site_info.location_long == 56.78
+        assert sites[0].site_info.igbp == "UNK"
         assert sites[0].product_data.first_year == 2000
         assert sites[0].product_data.last_year == 2020
-        assert str(sites[0].product_data.download_link) == "https://meta.icos-cp.eu/objects/US-ABC"
+        # Pre-encoded URL format: %5B=[, %5D=], %22="
+        assert (
+            str(sites[0].product_data.download_link) == "https://data.icos-cp.eu/licence_accept?ids=%5B%22US-ABC%22%5D"
+        )
 
         assert mock_request.call_count == 1
 
     @pytest.mark.asyncio
     @patch("fluxnet_shuttle_lib.plugins.icos.NetworkPlugin._session_request")
     async def test_async_get_sites_with_errors(self, mock_request, caplog):
-        """Test async get_sites method."""
+        """Test async get_sites method with invalid latitude."""
         mock_response = AsyncMock()
         mock_response.json.return_value = {
             "results": {
@@ -131,8 +140,108 @@ class TestICOSPlugin:
             async for site in plugin.get_sites():
                 sites.append(site)
 
+            # Site should still be yielded with fallback values
+            assert len(sites) == 1
+            assert sites[0].site_info.location_lat == 0.0  # Fallback value
+            assert sites[0].site_info.location_long == 56.78
+            assert sites[0].site_info.igbp == "UNK"
+
+            # Check that warning was logged
+            assert "Invalid latitude for station US-ABC" in caplog.text
+
+        assert mock_request.call_count == 1
+
+    def test_ecosystem_to_igbp_mapping(self):
+        """Test ecosystem type to IGBP mapping from ICOS URIs."""
+        plugin = ICOSPlugin()
+
+        # Test IGBP codes from ICOS URIs (the actual format ICOS uses)
+        assert plugin._map_ecosystem_to_igbp("http://meta.icos-cp.eu/ontologies/cpmeta/igbp_ENF") == "ENF"
+        assert plugin._map_ecosystem_to_igbp("http://meta.icos-cp.eu/ontologies/cpmeta/igbp_GRA") == "GRA"
+        assert plugin._map_ecosystem_to_igbp("http://meta.icos-cp.eu/ontologies/cpmeta/igbp_CRO") == "CRO"
+        assert plugin._map_ecosystem_to_igbp("http://meta.icos-cp.eu/ontologies/cpmeta/igbp_WET") == "WET"
+        assert plugin._map_ecosystem_to_igbp("http://meta.icos-cp.eu/ontologies/cpmeta/igbp_DBF") == "DBF"
+        assert plugin._map_ecosystem_to_igbp("http://meta.icos-cp.eu/ontologies/cpmeta/igbp_MF") == "MF"
+        assert plugin._map_ecosystem_to_igbp("http://meta.icos-cp.eu/ontologies/cpmeta/igbp_SAV") == "SAV"
+
+        # Test without URI prefix (just the igbp_XXX part)
+        assert plugin._map_ecosystem_to_igbp("igbp_ENF") == "ENF"
+        assert plugin._map_ecosystem_to_igbp("igbp_gra") == "GRA"  # Case insensitive
+
+        # Test empty and unknown types
+        assert plugin._map_ecosystem_to_igbp("") == "UNK"
+        assert plugin._map_ecosystem_to_igbp("unknown_type") == "UNK"
+        assert plugin._map_ecosystem_to_igbp("some_random_text") == "UNK"
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle_lib.plugins.icos.NetworkPlugin._session_request")
+    async def test_async_get_sites_with_invalid_longitude(self, mock_request, caplog):
+        """Test async get_sites method with invalid longitude."""
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "results": {
+                "bindings": [
+                    {
+                        "dobj": {"value": "https://meta.icos-cp.eu/objects/US-XYZ"},
+                        "station": {"value": "https://meta.icos-cp.eu/stations/US-XYZ"},
+                        "lat": {"value": "45.5"},
+                        "lon": {"value": "invalid_lon"},
+                        "timeStart": {"value": "2020-01-01T00:00:00Z"},
+                        "timeEnd": {"value": "2021-12-31T23:59:59Z"},
+                    }
+                ]
+            }
+        }
+        mock_request.return_value.__aenter__.return_value = mock_response
+
+        plugin = ICOSPlugin()
+
+        with caplog.at_level("WARNING"):
+            sites = []
+            async for site in plugin.get_sites():
+                sites.append(site)
+
+            # Site should still be yielded with fallback values
+            assert len(sites) == 1
+            assert sites[0].site_info.location_lat == 45.5
+            assert sites[0].site_info.location_long == 0.0  # Fallback value for invalid lon
+            assert sites[0].site_info.igbp == "UNK"
+
+            # Check that warning was logged
+            assert "Invalid longitude for station US-XYZ" in caplog.text
+
+        assert mock_request.call_count == 1
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle_lib.plugins.icos.NetworkPlugin._session_request")
+    async def test_async_get_sites_with_general_exception(self, mock_request, caplog):
+        """Test async get_sites handles general exceptions during parsing."""
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "results": {
+                "bindings": [
+                    {
+                        # Missing required 'dobj' field to trigger exception
+                        "station": {"value": "https://meta.icos-cp.eu/stations/US-BAD"},
+                        "lat": {"value": "40.0"},
+                        "lon": {"value": "-100.0"},
+                    }
+                ]
+            }
+        }
+        mock_request.return_value.__aenter__.return_value = mock_response
+
+        plugin = ICOSPlugin()
+
+        with caplog.at_level("WARNING"):
+            sites = []
+            async for site in plugin.get_sites():
+                sites.append(site)
+
+            # Should skip the malformed entry
             assert len(sites) == 0
 
-            assert "Error parsing ICOS site data: could not convert string to float: '12.34ff'" in caplog.text
+            # Check that warning was logged
+            assert "Error parsing ICOS site data" in caplog.text
 
         assert mock_request.call_count == 1


### PR DESCRIPTION
Resolves #13 by enhancing the ICOS plugin to fetch and populate latitude, longitude, and IGBP land cover classifications for all ICOS sites. This improves data completeness and enables better site characterization and filtering capabilities.

Changes:
- Extended SPARQL query to fetch lat, lon, and ecosystemType fields
- Implemented IGBP mapping from ICOS ecosystem URIs and keywords
- Added robust error handling for invalid coordinate values
- Updated download URL to use ICOS license acceptance endpoint
- Enhanced test coverage with IGBP mapping tests

Resolve issues #13 