### PR TITLE
feat(benchmarks): add benchmark integration tests and autosave workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,130 @@
+name: Benchmarks (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      python:
+        description: 'Python version'
+        required: true
+        default: '3.12'
+      run-name:
+        description: 'Name for this benchmark run (used with --benchmark-save)'
+        required: true
+        default: 'manual-run'
+      baseline:
+        description: 'Baseline name to compare against (optional)'
+        required: false
+        default: ''
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml', '**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # ensure test deps are present
+          pip install -e .[dev] || true
+          pip install pytest pytest-benchmark
+
+      - name: Ensure benchmarks dir exists
+        run: mkdir -p .benchmarks
+
+      - name: Download benchmark baseline (previous run, API)
+        if: ${{ inputs.baseline != '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+          NAME="benchmark-results-${{ inputs.baseline }}"
+          echo "Searching for artifact named: $NAME"
+ 
+          ARTIFACTS_JSON=$(curl -sS -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${REPO}/actions/artifacts?per_page=100")
+
+          ARTIFACT_ID=$(python - <<'PY'
+          import json, sys
+          data = json.load(sys.stdin)
+          name = sys.argv[1]
+          arts = data.get('artifacts', [])
+          matches = [a for a in arts if a.get('name') == name]
+          if not matches:
+              # no matches found
+              sys.exit(0)
+          # pick the latest by created_at (ISO timestamp)
+          latest = sorted(matches, key=lambda a: a.get('created_at') or '', reverse=True)[0]
+          print(latest.get('id'))
+          PY
+            "$NAME" <<<"$ARTIFACTS_JSON" || true)
+
+          if [ -z "$ARTIFACT_ID" ]; then
+            echo "Baseline artifact not found: $NAME"
+            exit 1
+          fi
+
+          echo "Found artifact id: $ARTIFACT_ID. Downloading..."
+          curl -sSL -H "Authorization: token $GITHUB_TOKEN" \
+          "https://api.github.com/repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o baseline.zip
+          unzip -o baseline.zip -d baseline_unzip
+          # Move .benchmarks into place (artifact may contain top-level folder)
+          if [ -d baseline_unzip/.benchmarks ]; then
+            rm -rf .benchmarks || true
+           mv baseline_unzip/.benchmarks ./
+          else
+            FOUND=$(find baseline_unzip -type d -name '.benchmarks' -print -quit || true)
+            if [ -n "$FOUND" ]; then
+              rm -rf .benchmarks || true
+              mv "$FOUND" ./
+            else
+              echo "Downloaded artifact did not contain a .benchmarks directory"
+              exit 1
+            fi
+          fi
+
+      - name: Record environment metadata
+        run: |
+          echo "runner: $RUNNER_OS" > .benchmarks/${{ inputs.run-name }}-meta.txt
+          echo "python: $(python -V)" >> .benchmarks/${{ inputs.run-name }}-meta.txt
+          uname -a >> .benchmarks/${{ inputs.run-name }}-meta.txt
+          lscpu || true
+
+      - name: Run benchmarks
+        env:
+          PYTHONHASHSEED: 0
+        run: |
+          pytest -m benchmark --benchmark-autosave --benchmark-save="${{ inputs.run-name }}"
+
+          if [ -n "${{ inputs.baseline }}" ]; then
+            echo "Comparing against baseline: ${{ inputs.baseline }}"
+            # remove '|| true' if you want the job to fail on compare exit codes
+            pytest -m benchmark --benchmark-compare="${{ inputs.baseline }}" || true
+          fi
+
+      - name: Upload benchmark artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ inputs.run-name }}
+          path: .benchmarks
+          retention-days: 30
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "Benchmark run '${{ inputs.run-name }}' finished. Artifact uploaded as 'benchmark-results-${{ inputs.run-name }}'."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,12 @@ pytest tests/test_core.py
 
 # Run tests with verbose output
 pytest -v
+
+# Run and save the benchmark integration tests
+pytest -m benchmark --benchmark-autosave --benchmark-storage=file:///tmp/fluxnet-shuttle-benchmarks
+ls -l /tmp/fluxnet-shuttle-benchmarks/*
+total 16
+-rw-r--r--@ 1 user  wheel  5184 Oct 30 12:59 0001_c5688d1539fdbfecd3c40ae823a1188fb304a97f_20251030_193028_uncommited-changes.json
 ```
 
 ### Building Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dev = [
     "flake8>=3.8",
     "types-requests",   
     "types-pyyaml",
-    "types-aiofiles"
+    "types-aiofiles",
+    "pytest-benchmark"
 ]
 docs = [
     "sphinx",
@@ -96,7 +97,7 @@ line_length = 120
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=fluxnet_shuttle --cov-report=term-missing -m 'not integration and not slow and not performance and not examples'"
+addopts = "--cov=fluxnet_shuttle --cov-report=term-missing -m 'not benchmark and not integration and not slow and not performance and not examples'"
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/tests/integration/test_plugin_ameriflux_integration.py
+++ b/tests/integration/test_plugin_ameriflux_integration.py
@@ -34,9 +34,11 @@ class TestAmeriFluxAPIIntegration:
             assert isinstance(sites, list)
 
             # If we got sites, verify they're FluxnetDatasetMetadata objects
-            if sites:
+            if sites and len(sites) > 0:
                 assert all(isinstance(site, FluxnetDatasetMetadata) for site in sites)
                 logging.info(f"Retrieved {len(sites)} AmeriFlux sites")
+            else:
+                pytest.fail("No sites were returned.")
 
         except requests.exceptions.RequestException as e:
             pytest.skip(f"AmeriFlux API not accessible: {e}")

--- a/tests/integration/test_plugin_icos_integration.py
+++ b/tests/integration/test_plugin_icos_integration.py
@@ -34,9 +34,11 @@ class TestICOSAPIIntegration:
             assert isinstance(sites, list)
 
             # If we got sites, verify they're FluxnetDatasetMetadata objects
-            if sites:
+            if sites and len(sites) > 0:
                 assert all(isinstance(site, FluxnetDatasetMetadata) for site in sites)
                 logging.info(f"Retrieved {len(sites)} ICOS sites")
+            else:
+                pytest.fail("No sites were returned.")
 
         except requests.exceptions.RequestException as e:
             pytest.skip(f"ICOS API not accessible: {e}")

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,48 @@
+"""Benchmark tests for the FluxnetShuttle library.
+
+These tests measure the performance for overall site retrieval
+from the FluxnetShuttle class as well as individual plugins like
+ICOS and AmeriFlux.
+"""
+
+import pytest
+
+# Import the plugins package to trigger auto-registration of available
+# plugins in the global registry.
+import fluxnet_shuttle.plugins  # noqa: F401
+from fluxnet_shuttle.core.registry import registry
+
+# Mark all tests in this file as integration/benchmark tests
+pytestmark = pytest.mark.benchmark
+
+
+@pytest.mark.parametrize("plugin_name", registry.list_plugins(), ids=registry.list_plugins())
+@pytest.mark.benchmark(group="get_sites")
+def test_benchmark_get_sites_for_plugin(plugin_name, benchmark):
+    """Benchmark get_sites() for every plugin currently registered.
+
+    This test dynamically discovers plugins from the global registry so
+    it will always exercise the latest enabled plugins without hardcoding
+    plugin classes.
+    """
+
+    # Try to create an instance of the plugin. If creation fails (missing
+    # configuration, etc.) we skip the benchmark for that plugin rather
+    # than failing the whole test suite.
+    try:
+        plugin = registry.create_instance(plugin_name)
+    except Exception as e:
+        pytest.skip(f"Could not create plugin '{plugin_name}': {e}")
+
+    def _call_get_sites():
+        # get_sites() is provided as a hybrid async/sync iterator by the
+        # plugins; converting to list exercises the full retrieval path.
+        return list(plugin.get_sites())
+
+    # Run the benchmark and skip the test if the plugin raises at runtime.
+    try:
+        sites = benchmark(_call_get_sites)
+    except Exception as e:
+        pytest.skip(f"Benchmark failed for plugin '{plugin_name}': {e}")
+
+    assert isinstance(sites, list)


### PR DESCRIPTION
Add integration-level benchmark tests and enable automatic benchmark saving for CI/local runs so benchmark results are persisted to directory of choice. This implements the changes requested in issue #27 and documents the run command in CONTRIBUTING.md. Also adds the workflow file to run and store benchmark results during CI.

Closes #27