### PR TITLE
feat(cli): implement CLI MVP improvements for issue #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,25 @@ fluxnet-shuttle listall --verbose
 #### `download`
 Download data for specific sites:
 ```bash
-fluxnet-shuttle download -r data_availability.csv -s US-ARc US-Bi1 IT-Niv
+# Download specific sites
+fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv -s US-ARc US-Bi1 IT-Niv
+
+# Download ALL sites from snapshot (prompts for confirmation)
+fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv
+
+# Download ALL sites without confirmation prompt
+fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv --quiet
 ```
-- Requires a CSV file from the `listall` command (`-r/--runfile`)
-- Specify site IDs with `-s/--sites`
-- Downloads are saved to the current directory
+- Requires a CSV snapshot file from the `listall` command (`-f/--snapshot-file`)
+- Specify site IDs with `-s/--sites` to download specific sites only
+- Omit `-s/--sites` to download all sites in the snapshot (will prompt for confirmation unless `--quiet` is used)
+- Downloads are saved to the output directory (default: current directory, use `-o` to specify)
 
 ### CLI Options
 - `-v/--verbose`: Enable detailed logging output
 - `-l/--logfile`: Specify log file path (default: `fluxnet-shuttle-run.log`)
 - `--no-logfile`: Disable file logging, output only to console
+- `--quiet/-q`: Skip confirmation prompt when downloading all sites from snapshot
 - `--version`: Show version information
 
 ### Example Workflow

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ Quick Start
 
     # Download specific sites
     sites = ['US-ARc', 'IT-Niv']
-    downloaded_files = download(site_ids=sites, runfile=csv_filename)
+    downloaded_files = download(site_ids=sites, snapshot_file=csv_filename)
 
 For advanced usage with error handling and the developer API, see :doc:`developer_guide`.
 
@@ -59,14 +59,17 @@ For advanced usage with error handling and the developer API, see :doc:`develope
 
 .. code-block:: bash
 
-    # List all available datasets
-    fluxnet-shuttle listall --verbose --output sites.csv
+    # List all available datasets (creates snapshot file)
+    fluxnet-shuttle listall
 
-    # Download data for specific sites
-    fluxnet-shuttle download -s US-Ha1 US-MMS -r sites.csv
+    # Download data for specific sites using snapshot file
+    fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv -s US-Ha1 US-MMS
 
-    # Run connectivity tests
-    fluxnet-shuttle test
+    # Create output directory
+    mkdir /data/fluxnet
+    fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv -s US-ARc IT-Niv -o /data/fluxnet
+
+For complete CLI documentation, see :doc:`cli`.
 
 Documentation
 =============


### PR DESCRIPTION
Refactors the command-line interface with modern argparse subparsers and adds critical features for better usability and automation.

Breaking Changes:
- Renamed --runfile/-r to --snapshot-file/-f for clarity
- Changed snapshot filename from data_availability_* to fluxnet_shuttle_snapshot_*
- Removed deprecated 'search' command

New Features:
- Added -o, --output-dir parameter to listall and download commands
- Added --quiet flag to skip confirmation when downloading all sites
- Implemented confirmation prompt when downloading all sites (unless --quiet used)
- Added dynamic sources command using plugin registry
- Fixed --version to display actual package version
- Each command now has dedicated help via subparsers

CLI Changes:
- Migrated from single positional command to argparse subparsers
- listall: Added -o/--output-dir for specifying output directory
- download: Changed -r/--runfile to -f/--snapshot-file (required)
- download: Made -s/--sites optional (downloads ALL if omitted)
- download: Added -o/--output-dir for downloaded files
- download: Added --quiet to skip download-all confirmation
- sources: Now dynamically queries plugin registry
- Removed: search, test command (deprecated)

Implementation:
- Updated main.py with complete subparser refactor
- Updated shuttle.py to support output_dir in listall() and download()
- Added directory creation and write permission validation
- Version now uses importlib.metadata for dynamic version display

Documentation:
- Updated docs/cli.rst with complete new command syntax
- Updated docs/index.rst with current examples
- Added workflow examples showing confirmation and --quiet usage

Resolves #15