### PR TITLE
feat: add code_version field, team member support, and citation retrieval

### DIFF
--- a/examples/fluxnet_shuttle_example.ipynb
+++ b/examples/fluxnet_shuttle_example.ipynb
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "3256ea52",
    "metadata": {},
    "outputs": [],
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "e4ca39b8",
    "metadata": {},
    "outputs": [
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "ca7139de",
    "metadata": {},
    "outputs": [
@@ -109,18 +109,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DEBUG:fluxnet_shuttle_lib.shuttle:Starting listall with (), {'ameriflux': True, 'icos': True}\n",
-      "DEBUG:fluxnet_shuttle_lib.shuttle:Networks to include: ['ameriflux', 'icos']\n",
-      "INFO:fluxnet_shuttle_lib.core.config:Loaded default configuration from package\n",
-      "INFO:fluxnet_shuttle_lib.core.shuttle:Initialized FluxnetShuttle with networks: ['ameriflux', 'icos']\n",
-      "INFO:fluxnet_shuttle_lib.plugins.ameriflux:Fetching AmeriFlux sites...\n",
-      "INFO:fluxnet_shuttle_lib.plugins.ameriflux:Found 299 AmeriFlux sites with FLUXNET data\n",
-      "INFO:fluxnet_shuttle_lib.plugins.icos:Fetching ICOS sites...\n",
-      "INFO:fluxnet_shuttle_lib.core.shuttle:Completed get_all_sites: 412 results, 0 errors\n",
-      "INFO:fluxnet_shuttle_lib.shuttle:Wrote data availability to data_availability_20251013T165229.csv\n",
-      "INFO:fluxnet_shuttle_lib.shuttle:Network counts: {'AmeriFlux': 299, 'ICOS': 113}\n",
+      "DEBUG:fluxnet_shuttle.shuttle:Starting listall with (), {'ameriflux': True, 'icos': True}\n",
+      "DEBUG:fluxnet_shuttle.shuttle:Data hubs to include: ['ameriflux', 'icos']\n",
+      "INFO:fluxnet_shuttle.core.config:Loaded default configuration from package\n",
+      "INFO:fluxnet_shuttle.core.shuttle:Initialized FluxnetShuttle with data hubs: ['ameriflux', 'icos']\n",
+      "INFO:fluxnet_shuttle.plugins.ameriflux:Fetching AmeriFlux sites...\n",
+      "INFO:fluxnet_shuttle.plugins.ameriflux:Retrieved metadata for 298 AmeriFlux sites\n",
+      "INFO:fluxnet_shuttle.plugins.ameriflux:Retrieved download links for 298 sites\n",
+      "INFO:fluxnet_shuttle.plugins.ameriflux:Retrieved citations for 298 sites\n",
+      "INFO:fluxnet_shuttle.plugins.icos:Fetching ICOS sites...\n",
+      "INFO:fluxnet_shuttle.core.shuttle:Completed get_all_sites: 411 results, 0 errors\n",
+      "INFO:fluxnet_shuttle.shuttle:Wrote FLUXNET dataset snapshot to ./fluxnet_shuttle_snapshot_20251126T090350.csv\n",
+      "INFO:fluxnet_shuttle.shuttle:Data hub counts: {'AmeriFlux': 298, 'ICOS': 113}\n",
       "\n",
-      "Data catalog saved to: data_availability_20251013T165229.csv\n"
+      "Data catalog saved to: ./fluxnet_shuttle_snapshot_20251126T090350.csv\n"
      ]
     }
    ],
@@ -141,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "6e7a602f",
    "metadata": {},
    "outputs": [
@@ -149,98 +151,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found 412 available datasets\n",
+      "Found 411 available datasets\n",
       "\n",
-      "Catalog columns: ['network', 'site_id', 'first_year', 'last_year', 'download_link']\n",
+      "Catalog columns: ['data_hub', 'site_id', 'site_name', 'location_lat', 'location_long', 'igbp', 'team_member_name', 'team_member_role', 'team_member_email', 'first_year', 'last_year', 'download_link', 'product_citation', 'product_id', 'code_version']\n",
       "\n",
       "Data summary:\n",
-      "  Networks: {'AmeriFlux': 299, 'ICOS': 113}\n",
+      "  Networks: {'AmeriFlux': 298, 'ICOS': 113}\n",
       "  Date range: 1991 - 2024\n"
      ]
     },
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "index",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "network",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "site_id",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "first_year",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "last_year",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "download_link",
-         "rawType": "object",
-         "type": "string"
-        }
-       ],
-       "ref": "87a5df30-f695-4384-8114-6c3fed75032d",
-       "rows": [
-        [
-         "0",
-         "AmeriFlux",
-         "AR-Bal",
-         "2012",
-         "2013",
-         "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/AMF_AR-Bal_FLUXNET_FULLSET_2012-2013_3-7.zip?=fluxnetshuttle"
-        ],
-        [
-         "1",
-         "AmeriFlux",
-         "AR-CCa",
-         "2012",
-         "2020",
-         "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/AMF_AR-CCa_FLUXNET_FULLSET_2012-2020_3-7.zip?=fluxnetshuttle"
-        ],
-        [
-         "2",
-         "AmeriFlux",
-         "AR-CCg",
-         "2018",
-         "2024",
-         "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/AMF_AR-CCg_FLUXNET_FULLSET_2018-2024_4-7.zip?=fluxnetshuttle"
-        ],
-        [
-         "3",
-         "AmeriFlux",
-         "AR-TF1",
-         "2016",
-         "2018",
-         "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/AMF_AR-TF1_FLUXNET_FULLSET_2016-2018_5-7.zip?=fluxnetshuttle"
-        ],
-        [
-         "4",
-         "AmeriFlux",
-         "AR-TF2",
-         "2016",
-         "2018",
-         "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/AMF_AR-TF2_FLUXNET_FULLSET_2016-2018_3-7.zip?=fluxnetshuttle"
-        ]
-       ],
-       "shape": {
-        "columns": 5,
-        "rows": 5
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -260,11 +181,21 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>network</th>\n",
+       "      <th>data_hub</th>\n",
        "      <th>site_id</th>\n",
+       "      <th>site_name</th>\n",
+       "      <th>location_lat</th>\n",
+       "      <th>location_long</th>\n",
+       "      <th>igbp</th>\n",
+       "      <th>team_member_name</th>\n",
+       "      <th>team_member_role</th>\n",
+       "      <th>team_member_email</th>\n",
        "      <th>first_year</th>\n",
        "      <th>last_year</th>\n",
        "      <th>download_link</th>\n",
+       "      <th>product_citation</th>\n",
+       "      <th>product_id</th>\n",
+       "      <th>code_version</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -272,60 +203,145 @@
        "      <th>0</th>\n",
        "      <td>AmeriFlux</td>\n",
        "      <td>AR-Bal</td>\n",
+       "      <td>Balcarce BA</td>\n",
+       "      <td>-37.7596</td>\n",
+       "      <td>-58.3024</td>\n",
+       "      <td>CRO</td>\n",
+       "      <td>Maria Isabel Gassmann;Natalia Edith Tonti;Nahu...</td>\n",
+       "      <td>PI;PI;DataManager;Technician;Technician</td>\n",
+       "      <td>gassmann@at.fcen.uba.ar;ntonti@at.fcen.uba.ar;...</td>\n",
        "      <td>2012</td>\n",
        "      <td>2013</td>\n",
        "      <td>https://ftp.fluxdata.org/.ameriflux_downloads/...</td>\n",
+       "      <td>Maria Isabel Gassmann, Natalia Edith Tonti (20...</td>\n",
+       "      <td>10.17190/AMF/2571144</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>AmeriFlux</td>\n",
        "      <td>AR-CCa</td>\n",
+       "      <td>Carlos Casares agriculture</td>\n",
+       "      <td>-35.6210</td>\n",
+       "      <td>-61.3181</td>\n",
+       "      <td>CRO</td>\n",
+       "      <td>Gabriela Posse;Patricio Oricchio;Klaus Richter</td>\n",
+       "      <td>PI;Technician;Affiliate</td>\n",
+       "      <td>posse.gabriela@gmail.com;oricchio.patricio@int...</td>\n",
        "      <td>2012</td>\n",
        "      <td>2020</td>\n",
        "      <td>https://ftp.fluxdata.org/.ameriflux_downloads/...</td>\n",
+       "      <td>Gabriela Posse (2025), AmeriFlux FLUXNET-1F AR...</td>\n",
+       "      <td>10.17190/AMF/2571134</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>AmeriFlux</td>\n",
        "      <td>AR-CCg</td>\n",
+       "      <td>Carlos Casares grassland</td>\n",
+       "      <td>-35.9244</td>\n",
+       "      <td>-61.1855</td>\n",
+       "      <td>GRA</td>\n",
+       "      <td>Gabriela Posse;Patricio Oricchio;Carlos Di Bella</td>\n",
+       "      <td>PI;Technician;Affiliate</td>\n",
+       "      <td>posse.gabriela@gmail.com;oricchio.patricio@int...</td>\n",
        "      <td>2018</td>\n",
        "      <td>2024</td>\n",
        "      <td>https://ftp.fluxdata.org/.ameriflux_downloads/...</td>\n",
+       "      <td>Gabriela Posse (2025), AmeriFlux FLUXNET-1F AR...</td>\n",
+       "      <td>10.17190/AMF/2469434</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>AmeriFlux</td>\n",
        "      <td>AR-TF1</td>\n",
+       "      <td>Rio Moat bog</td>\n",
+       "      <td>-54.9733</td>\n",
+       "      <td>-66.7335</td>\n",
+       "      <td>WET</td>\n",
+       "      <td>Lars Kutzbach;Veronica Pancotto;David Holl</td>\n",
+       "      <td>PI;PI;DataManager</td>\n",
+       "      <td>lars.kutzbach@uni-hamburg.de;pancotto@cadic-co...</td>\n",
        "      <td>2016</td>\n",
        "      <td>2018</td>\n",
        "      <td>https://ftp.fluxdata.org/.ameriflux_downloads/...</td>\n",
+       "      <td>Lars Kutzbach (2025), AmeriFlux FLUXNET-1F AR-...</td>\n",
+       "      <td>10.17190/AMF/1818370</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>AmeriFlux</td>\n",
        "      <td>AR-TF2</td>\n",
+       "      <td>Rio Pipo bog</td>\n",
+       "      <td>-54.8269</td>\n",
+       "      <td>-68.4549</td>\n",
+       "      <td>WET</td>\n",
+       "      <td>Lars Kutzbach;Veronica Pancotto;David Holl</td>\n",
+       "      <td>PI;PI;DataManager</td>\n",
+       "      <td>lars.kutzbach@uni-hamburg.de;pancotto@cadic-co...</td>\n",
        "      <td>2016</td>\n",
        "      <td>2018</td>\n",
        "      <td>https://ftp.fluxdata.org/.ameriflux_downloads/...</td>\n",
+       "      <td>Lars Kutzbach (2025), AmeriFlux FLUXNET-1F AR-...</td>\n",
+       "      <td>10.17190/AMF/2571120</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "     network site_id  first_year  last_year  \\\n",
-       "0  AmeriFlux  AR-Bal        2012       2013   \n",
-       "1  AmeriFlux  AR-CCa        2012       2020   \n",
-       "2  AmeriFlux  AR-CCg        2018       2024   \n",
-       "3  AmeriFlux  AR-TF1        2016       2018   \n",
-       "4  AmeriFlux  AR-TF2        2016       2018   \n",
+       "    data_hub site_id                   site_name  location_lat  location_long  \\\n",
+       "0  AmeriFlux  AR-Bal                 Balcarce BA      -37.7596       -58.3024   \n",
+       "1  AmeriFlux  AR-CCa  Carlos Casares agriculture      -35.6210       -61.3181   \n",
+       "2  AmeriFlux  AR-CCg    Carlos Casares grassland      -35.9244       -61.1855   \n",
+       "3  AmeriFlux  AR-TF1                Rio Moat bog      -54.9733       -66.7335   \n",
+       "4  AmeriFlux  AR-TF2                Rio Pipo bog      -54.8269       -68.4549   \n",
        "\n",
-       "                                       download_link  \n",
-       "0  https://ftp.fluxdata.org/.ameriflux_downloads/...  \n",
-       "1  https://ftp.fluxdata.org/.ameriflux_downloads/...  \n",
-       "2  https://ftp.fluxdata.org/.ameriflux_downloads/...  \n",
-       "3  https://ftp.fluxdata.org/.ameriflux_downloads/...  \n",
-       "4  https://ftp.fluxdata.org/.ameriflux_downloads/...  "
+       "  igbp                                   team_member_name  \\\n",
+       "0  CRO  Maria Isabel Gassmann;Natalia Edith Tonti;Nahu...   \n",
+       "1  CRO     Gabriela Posse;Patricio Oricchio;Klaus Richter   \n",
+       "2  GRA   Gabriela Posse;Patricio Oricchio;Carlos Di Bella   \n",
+       "3  WET         Lars Kutzbach;Veronica Pancotto;David Holl   \n",
+       "4  WET         Lars Kutzbach;Veronica Pancotto;David Holl   \n",
+       "\n",
+       "                          team_member_role  \\\n",
+       "0  PI;PI;DataManager;Technician;Technician   \n",
+       "1                  PI;Technician;Affiliate   \n",
+       "2                  PI;Technician;Affiliate   \n",
+       "3                        PI;PI;DataManager   \n",
+       "4                        PI;PI;DataManager   \n",
+       "\n",
+       "                                   team_member_email  first_year  last_year  \\\n",
+       "0  gassmann@at.fcen.uba.ar;ntonti@at.fcen.uba.ar;...        2012       2013   \n",
+       "1  posse.gabriela@gmail.com;oricchio.patricio@int...        2012       2020   \n",
+       "2  posse.gabriela@gmail.com;oricchio.patricio@int...        2018       2024   \n",
+       "3  lars.kutzbach@uni-hamburg.de;pancotto@cadic-co...        2016       2018   \n",
+       "4  lars.kutzbach@uni-hamburg.de;pancotto@cadic-co...        2016       2018   \n",
+       "\n",
+       "                                       download_link  \\\n",
+       "0  https://ftp.fluxdata.org/.ameriflux_downloads/...   \n",
+       "1  https://ftp.fluxdata.org/.ameriflux_downloads/...   \n",
+       "2  https://ftp.fluxdata.org/.ameriflux_downloads/...   \n",
+       "3  https://ftp.fluxdata.org/.ameriflux_downloads/...   \n",
+       "4  https://ftp.fluxdata.org/.ameriflux_downloads/...   \n",
+       "\n",
+       "                                    product_citation            product_id  \\\n",
+       "0  Maria Isabel Gassmann, Natalia Edith Tonti (20...  10.17190/AMF/2571144   \n",
+       "1  Gabriela Posse (2025), AmeriFlux FLUXNET-1F AR...  10.17190/AMF/2571134   \n",
+       "2  Gabriela Posse (2025), AmeriFlux FLUXNET-1F AR...  10.17190/AMF/2469434   \n",
+       "3  Lars Kutzbach (2025), AmeriFlux FLUXNET-1F AR-...  10.17190/AMF/1818370   \n",
+       "4  Lars Kutzbach (2025), AmeriFlux FLUXNET-1F AR-...  10.17190/AMF/2571120   \n",
+       "\n",
+       "   code_version  \n",
+       "0           NaN  \n",
+       "1           NaN  \n",
+       "2           NaN  \n",
+       "3           NaN  \n",
+       "4           NaN  "
       ]
      },
      "execution_count": 4,
@@ -339,7 +355,7 @@
     "print(f\"Found {len(catalog)} available datasets\")\n",
     "print(f\"\\nCatalog columns: {list(catalog.columns)}\")\n",
     "print(f\"\\nData summary:\")\n",
-    "print(f\"  Networks: {catalog['network'].value_counts().to_dict()}\")\n",
+    "print(f\"  Networks: {catalog['data_hub'].value_counts().to_dict()}\")\n",
     "print(f\"  Date range: {catalog['first_year'].min()} - {catalog['last_year'].max()}\")\n",
     "\n",
     "# Display first few rows\n",
@@ -384,14 +400,14 @@
     "selected_sites = catalog[catalog[\"site_id\"].isin(sites)]\n",
     "print(\"Selected sites for download:\")\n",
     "for _, site in selected_sites.iterrows():\n",
-    "    print(f\"  {site['site_id']} ({site['network']}): {site['first_year']}-{site['last_year']}\")\n",
+    "    print(f\"  {site['site_id']} ({site['data_hub']}): {site['first_year']}-{site['last_year']}\")\n",
     "\n",
     "print(f\"\\nTotal file size to download: {len(sites)} files\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "215fa1e3",
    "metadata": {},
    "outputs": [
@@ -399,29 +415,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:fluxnet_shuttle_lib.shuttle:Starting download with site IDs: ['US-ARc', 'IT-Niv'] and run file: data_availability_20251013T165229.csv\n",
-      "DEBUG:fluxnet_shuttle_lib.shuttle:Loaded 412 sites from run file\n",
-      "DEBUG:fluxnet_shuttle_lib.shuttle:All site IDs found in run file\n",
-      "INFO:fluxnet_shuttle_lib.shuttle:Downloading data for site US-ARc from network AmeriFlux\n",
-      "INFO:fluxnet_shuttle_lib.sources.ameriflux:AmeriFlux Portal: downloading AmeriFlux site US-ARc data file: AMF_US-ARc_FLUXNET_FULLSET_2005-2006_5-7.zip?=fluxnetshuttle\n",
+      "DEBUG:fluxnet_shuttle.shuttle:Loaded 411 sites from snapshot file\n",
+      "INFO:fluxnet_shuttle.shuttle:Starting download with 2 site IDs: ['US-ARc', 'IT-Niv'] and snapshot file: ./fluxnet_shuttle_snapshot_20251126T090350.csv\n",
+      "DEBUG:fluxnet_shuttle.shuttle:All site IDs found in snapshot file\n",
+      "INFO:fluxnet_shuttle.shuttle:Downloading data for site US-ARc from data hub AmeriFlux\n",
+      "INFO:fluxnet_shuttle.shuttle:AmeriFlux: downloading site US-ARc data file: AMF_US-ARc_FLUXNET_FULLSET_2005-2006_5-7.zip\n",
       "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): ftp.fluxdata.org:443\n",
       "DEBUG:urllib3.connectionpool:https://ftp.fluxdata.org:443 \"GET /.ameriflux_downloads/FLUXNET/AMF_US-ARc_FLUXNET_FULLSET_2005-2006_5-7.zip?=fluxnetshuttle HTTP/1.1\" 200 28104809\n",
-      "INFO:fluxnet_shuttle_lib.sources.ameriflux:AmeriFlux Portal: AmeriFlux file downloaded successfully to AMF_US-ARc_FLUXNET_FULLSET_2005-2006_5-7.zip?=fluxnetshuttle\n",
-      "INFO:fluxnet_shuttle_lib.shuttle:Downloading data for site IT-Niv from network ICOS\n",
-      "INFO:fluxnet_shuttle_lib.sources.icos:ICOS Carbon Portal: Downloading ICOS site IT-Niv data file: V5GmP7yPO_JK005msvdCvVe1\n",
+      "INFO:fluxnet_shuttle.shuttle:AmeriFlux: file downloaded successfully to ./AMF_US-ARc_FLUXNET_FULLSET_2005-2006_5-7.zip\n",
+      "INFO:fluxnet_shuttle.shuttle:Downloading data for site IT-Niv from data hub ICOS\n",
+      "INFO:fluxnet_shuttle.shuttle:ICOS: downloading site IT-Niv data file: licence_accept\n",
       "DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): data.icos-cp.eu:443\n",
       "DEBUG:urllib3.connectionpool:https://data.icos-cp.eu:443 \"GET /licence_accept?ids=%5B%22V5GmP7yPO_JK005msvdCvVe1%22%5D HTTP/1.1\" 302 106\n",
       "DEBUG:urllib3.connectionpool:https://data.icos-cp.eu:443 \"GET /objects/V5GmP7yPO_JK005msvdCvVe1 HTTP/1.1\" 200 55761302\n",
-      "INFO:fluxnet_shuttle_lib.sources.icos:ICOS Carbon Portal: ICOS file downloaded successfully to V5GmP7yPO_JK005msvdCvVe1\n",
-      "INFO:fluxnet_shuttle_lib.shuttle:Downloaded data for 2 sites: ['US-ARc', 'IT-Niv']\n",
+      "DEBUG:fluxnet_shuttle.shuttle:Using filename from Content-Disposition header: FLX_IT-Niv_FLUXNET2015_FULLSET_2019-2023_1-3.zip\n",
+      "INFO:fluxnet_shuttle.shuttle:ICOS: file downloaded successfully to ./FLX_IT-Niv_FLUXNET2015_FULLSET_2019-2023_1-3.zip\n",
+      "INFO:fluxnet_shuttle.shuttle:Downloaded data for 2 sites: ['US-ARc', 'IT-Niv']\n",
       "\n",
-      "Downloaded files: ['AMF_US-ARc_FLUXNET_FULLSET_2005-2006_5-7.zip?=fluxnetshuttle', 'V5GmP7yPO_JK005msvdCvVe1']\n"
+      "Downloaded files: ['./AMF_US-ARc_FLUXNET_FULLSET_2005-2006_5-7.zip', './FLX_IT-Niv_FLUXNET2015_FULLSET_2019-2023_1-3.zip']\n"
      ]
     }
    ],
    "source": [
     "# Download the data files for the specified sites (data download times depend on connection speed)\n",
-    "downloaded_filenames = download(site_ids=sites, runfile=csv_filename)\n",
+    "downloaded_filenames = download(site_ids=sites, snapshot_file=csv_filename)\n",
     "print(f\"\\nDownloaded files: {downloaded_filenames}\")"
    ]
   },
@@ -435,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "9c58bae9",
    "metadata": {},
    "outputs": [
@@ -443,7 +460,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extracted all files to AMF_US-ARc_FLUXNET_FULLSET_2005-2006_5-7.zip?=fluxnetshu_extracted\n",
+      "Extracted all files to ./AMF_US-ARc_FLUXNET_FULLSET_2005-2006_5-7_extracted\n",
       "\n",
       "Extracted 12 files:\n",
       "  AMF_US-ARc_FLUXNET_FULLSET_HH_2005-2006_5-7.csv\n",
@@ -504,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "6a109271",
    "metadata": {},
    "outputs": [
@@ -512,7 +529,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loading half-hourly data from: AMF_US-ARc_FLUXNET_FULLSET_2005-2006_5-7.zip?=fluxnetshu_extracted/AMF_US-ARc_FLUXNET_FULLSET_HH_2005-2006_5-7.csv\n",
+      "Loading half-hourly data from: ./AMF_US-ARc_FLUXNET_FULLSET_2005-2006_5-7_extracted/AMF_US-ARc_FLUXNET_FULLSET_HH_2005-2006_5-7.csv\n",
       "\n",
       "Data loaded successfully:\n",
       "  Shape: (35040, 143)\n",
@@ -557,7 +574,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "d7eda671",
    "metadata": {},
    "outputs": [
@@ -2074,9 +2091,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "fluxnet-shuttle-lib",
+   "display_name": "Python (fluxnet-shuttle-lib)",
    "language": "python",
-   "name": "python3"
+   "name": "fluxnet-shuttle-lib"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2088,7 +2105,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.13.6"
   }
  },
  "nbformat": 4,

--- a/src/fluxnet_shuttle/core/base.py
+++ b/src/fluxnet_shuttle/core/base.py
@@ -129,7 +129,7 @@ class DataHubPlugin(ABC):
     @abstractmethod
     def display_name(self) -> str:
         """
-        Human-readable data hub name.
+        Data hub name.
 
         Returns:
             str: Display name for the data hub (e.g., 'AmeriFlux', 'ICOS')

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -109,11 +109,11 @@ def sample_ameriflux_response():
         "data_urls": [
             {
                 "site_id": "US-ARM",
-                "url": "https://example.com/FLX_US-ARM_FLUXNET2015_FULLSET_2003-2012_1.zip",
+                "url": "https://example.com/FLX_US-ARM_FLUXNET_2003-2012_v1_r0.zip",
             },
             {
                 "site_id": "US-Ton",
-                "url": "https://example.com/FLX_US-Ton_FLUXNET2015_FULLSET_2001-2014_1.zip",
+                "url": "https://example.com/FLX_US-Ton_FLUXNET_2001-2014_v1_r0.zip",
             },
         ]
     }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,10 +34,22 @@ class MockDataHubPlugin(DataHubPlugin):
     async def get_sites(self, **filters) -> AsyncGenerator[FluxnetDatasetMetadata, None]:
         """Mock implementation that yields test data."""
         site_info = BadmSiteGeneralInfo(
-            site_id="US-TEST", data_hub="Mock", location_lat=40.0, location_long=-100.0, igbp="DBF"
+            site_id="US-TEST",
+            site_name="Test Site",
+            data_hub="Mock",
+            location_lat=40.0,
+            location_long=-100.0,
+            igbp="DBF",
         )
 
-        product_data = DataFluxnetProduct(first_year=2020, last_year=2021, download_link="https://example.com/test.zip")
+        product_data = DataFluxnetProduct(
+            first_year=2020,
+            last_year=2021,
+            download_link="https://example.com/test.zip",
+            product_citation="Test citation",
+            product_id="test-id",
+            code_version="v1",
+        )
 
         yield FluxnetDatasetMetadata(site_info=site_info, product_data=product_data)
 

--- a/tests/test_core_shuttle.py
+++ b/tests/test_core_shuttle.py
@@ -56,11 +56,21 @@ class MockSuccessPlugin:
         for _ in range(4):  # Simulate some async operation
             await asyncio.sleep(0.1)
             site_info = BadmSiteGeneralInfo(
-                site_id="US-SUCCESS", data_hub="Success", location_lat=45.0, location_long=-95.0, igbp="DBF"
+                site_id="US-SUCCESS",
+                site_name="Success Site",
+                data_hub="Success",
+                location_lat=45.0,
+                location_long=-95.0,
+                igbp="DBF",
             )
 
             product_data = DataFluxnetProduct(
-                first_year=2019, last_year=2020, download_link="https://example.com/success.zip"
+                first_year=2019,
+                last_year=2020,
+                download_link="https://example.com/success.zip",
+                product_citation="Test citation",
+                product_id="test-id",
+                code_version="v1",
             )
 
             yield FluxnetDatasetMetadata(site_info=site_info, product_data=product_data)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,6 +27,7 @@ def sample_site_info():
     """Fixture providing sample site general information."""
     return BadmSiteGeneralInfo(
         site_id="US-ARc",
+        site_name="Utqiaġvik (Barrow)",
         data_hub="AmeriFlux",
         location_lat=68.1396,
         location_long=-149.5892,
@@ -37,7 +38,14 @@ def sample_site_info():
 @pytest.fixture
 def sample_product_data():
     """Fixture providing sample product data."""
-    return DataFluxnetProduct(first_year=2018, last_year=2023, download_link="https://example.com/dataset.zip")
+    return DataFluxnetProduct(
+        first_year=2018,
+        last_year=2023,
+        download_link="https://example.com/dataset.zip",
+        product_citation="Test citation",
+        product_id="test-id-123",
+        code_version="v1",
+    )
 
 
 @pytest.fixture
@@ -66,6 +74,7 @@ def test_badm_site_general_info_site_id_validation():
     for site_id in valid_site_ids:
         site_info = BadmSiteGeneralInfo(
             site_id=site_id,
+            site_name="Test Site",
             data_hub="AmeriFlux",
             location_lat=45.0,
             location_long=2.0,
@@ -79,6 +88,7 @@ def test_badm_site_general_info_site_id_validation():
         with pytest.raises(ValidationError):
             BadmSiteGeneralInfo(
                 site_id=site_id,
+                site_name="Test Site",
                 data_hub="AmeriFlux",
                 location_lat=45.0,
                 location_long=2.0,
@@ -93,6 +103,7 @@ def test_badm_site_general_info_latitude_validation():
     for lat in valid_lats:
         site_info = BadmSiteGeneralInfo(
             site_id="US-ARc",
+            site_name="Test Site",
             data_hub="AmeriFlux",
             location_lat=lat,
             location_long=0.0,
@@ -106,6 +117,7 @@ def test_badm_site_general_info_latitude_validation():
         with pytest.raises(ValidationError):
             BadmSiteGeneralInfo(
                 site_id="US-ARc",
+                site_name="Test Site",
                 data_hub="AmeriFlux",
                 location_lat=lat,
                 location_long=0.0,
@@ -120,6 +132,7 @@ def test_badm_site_general_info_longitude_validation():
     for lon in valid_lons:
         site_info = BadmSiteGeneralInfo(
             site_id="US-ARc",
+            site_name="Test Site",
             data_hub="AmeriFlux",
             location_lat=0.0,
             location_long=lon,
@@ -133,6 +146,7 @@ def test_badm_site_general_info_longitude_validation():
         with pytest.raises(ValidationError):
             BadmSiteGeneralInfo(
                 site_id="US-ARc",
+                site_name="Test Site",
                 data_hub="AmeriFlux",
                 location_lat=0.0,
                 location_long=lon,
@@ -169,6 +183,9 @@ def test_data_fluxnet_product_year_validation():
             first_year=first_year,
             last_year=last_year,
             download_link="https://example.com/dataset.zip",
+            product_citation="Test citation",
+            product_id="test-id",
+            code_version="v1",
         )
         assert product.first_year == first_year
         assert product.last_year == last_year
@@ -179,6 +196,9 @@ def test_data_fluxnet_product_year_validation():
             first_year=1899,  # Below minimum
             last_year=2000,
             download_link="https://example.com/dataset.zip",
+            product_citation="Test citation",
+            product_id="test-id",
+            code_version="v1",
         )
 
     with pytest.raises(ValidationError):
@@ -186,6 +206,9 @@ def test_data_fluxnet_product_year_validation():
             first_year=2000,
             last_year=2101,  # Above maximum
             download_link="https://example.com/dataset.zip",
+            product_citation="Test citation",
+            product_id="test-id",
+            code_version="v1",
         )
 
     # Invalid year range (last_year < first_year)
@@ -194,6 +217,9 @@ def test_data_fluxnet_product_year_validation():
             first_year=2023,
             last_year=2020,
             download_link="https://example.com/dataset.zip",
+            product_citation="Test citation",
+            product_id="test-id",
+            code_version="v1",
         )
 
 
@@ -206,7 +232,14 @@ def test_data_fluxnet_product_url_validation():
         "https://icos-cp.eu/data/file.nc",
     ]
     for url in valid_urls:
-        product = DataFluxnetProduct(first_year=2018, last_year=2023, download_link=url)
+        product = DataFluxnetProduct(
+            first_year=2018,
+            last_year=2023,
+            download_link=url,
+            product_citation="Test citation",
+            product_id="test-id",
+            code_version="v1",
+        )
         assert str(product.download_link) == url
 
     # Invalid URLs
@@ -219,7 +252,14 @@ def test_data_fluxnet_product_url_validation():
     ]
     for url in invalid_urls:
         with pytest.raises(ValidationError):
-            DataFluxnetProduct(first_year=2018, last_year=2023, download_link=url)
+            DataFluxnetProduct(
+                first_year=2018,
+                last_year=2023,
+                download_link=url,
+                product_citation="Test citation",
+                product_id="test-id",
+                code_version="v1",
+            )
 
 
 # Tests for FluxnetDatasetMetadata
@@ -236,6 +276,7 @@ def test_fluxnet_dataset_metadata_nested_validation():
         FluxnetDatasetMetadata(
             site_info=BadmSiteGeneralInfo(
                 site_id="INVALID",  # Bad format
+                site_name="Test Site",
                 data_hub="AmeriFlux",
                 location_lat=68.1396,
                 location_long=-149.5892,
@@ -245,6 +286,9 @@ def test_fluxnet_dataset_metadata_nested_validation():
                 first_year=2018,
                 last_year=2023,
                 download_link="https://example.com/dataset.zip",
+                product_citation="Test citation",
+                product_id="test-id",
+                code_version="v1",
             ),
         )
 
@@ -253,6 +297,7 @@ def test_fluxnet_dataset_metadata_nested_validation():
         FluxnetDatasetMetadata(
             site_info=BadmSiteGeneralInfo(
                 site_id="US-ARc",
+                site_name="Test Site",
                 data_hub="AmeriFlux",
                 location_lat=68.1396,
                 location_long=-149.5892,
@@ -262,6 +307,9 @@ def test_fluxnet_dataset_metadata_nested_validation():
                 first_year=2023,
                 last_year=2020,  # Invalid range
                 download_link="https://example.com/dataset.zip",
+                product_citation="Test citation",
+                product_id="test-id",
+                code_version="v1",
             ),
         )
 

--- a/tests/test_plugin_ameriflux.py
+++ b/tests/test_plugin_ameriflux.py
@@ -20,18 +20,23 @@ class TestAmeriFluxPlugin:
 
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_download_links")
-    def test_get_sites_success(self, mock_get_links, mock_get_metadata):
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_citations")
+    def test_get_sites_success(self, mock_get_citations, mock_get_links, mock_get_metadata):
         """Test successful retrieval of sites."""
         mock_get_metadata.return_value = {
             "AR-Bal": {
+                "site_name": "Balcarce BA",
                 "grp_location": {"location_lat": "-37.7596", "location_long": "-58.3024"},
                 "grp_igbp": {"igbp": "CRO"},
                 "grp_publish_fluxnet": [2012, 2013],
+                "doi": {"AmeriFlux": "10.17190/AMF/2315764", "FLUXNET": "10.17190/AMF/2571144"},
             },
             "AR-CCa": {
+                "site_name": "Carmen del Aza",
                 "grp_location": {"location_lat": "-31.4821", "location_long": "-63.6458"},
                 "grp_igbp": {"igbp": "GRA"},
                 "grp_publish_fluxnet": [2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020],
+                "doi": {"AmeriFlux": "10.17190/AMF/1880910", "FLUXNET": "10.17190/AMF/2571134"},
             },
         }
         mock_get_links.return_value = {
@@ -39,14 +44,18 @@ class TestAmeriFluxPlugin:
                 {
                     "site_id": "AR-Bal",
                     "url": "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/"
-                    "AMF_AR-Bal_FLUXNET_FULLSET_2012-2013_3-7.zip",
+                    "AMF_AR-Bal_FLUXNET_2012-2013_v3_r7.zip",
                 },
                 {
                     "site_id": "AR-CCa",
                     "url": "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/"
-                    "AMF_AR-CCa_FLUXNET_FULLSET_2012-2020_3-7.zip",
+                    "AMF_AR-CCa_FLUXNET_2012-2020_v3_r7.zip",
                 },
             ]
+        }
+        mock_get_citations.return_value = {
+            "AR-Bal": "Citation for AR-Bal site",
+            "AR-CCa": "Citation for AR-CCa site",
         }
 
         plugin = ameriflux.AmeriFluxPlugin()
@@ -54,35 +63,41 @@ class TestAmeriFluxPlugin:
 
         assert len(sites) == 2
         assert sites[0].site_info.site_id == "AR-Bal"
+        assert sites[0].site_info.site_name == "Balcarce BA"
         assert sites[0].product_data.first_year == 2012
         assert sites[0].product_data.last_year == 2013
         assert (
             str(sites[0].product_data.download_link)
-            == "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/AMF_AR-Bal_FLUXNET_FULLSET_2012-2013_3-7.zip"
+            == "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/AMF_AR-Bal_FLUXNET_2012-2013_v3_r7.zip"
         )
         assert sites[0].site_info.data_hub == "AmeriFlux"
         assert sites[0].site_info.location_lat == -37.7596  # Real value from metadata
         assert sites[0].site_info.location_long == -58.3024  # Real value from metadata
         assert sites[0].site_info.igbp == "CRO"  # Real value from metadata
+        assert sites[0].product_data.product_id == "10.17190/AMF/2571144"  # FLUXNET DOI
 
         assert sites[1].site_info.site_id == "AR-CCa"
+        assert sites[1].site_info.site_name == "Carmen del Aza"
         assert sites[1].product_data.first_year == 2012
         assert sites[1].product_data.last_year == 2020
         assert (
             str(sites[1].product_data.download_link)
-            == "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/AMF_AR-CCa_FLUXNET_FULLSET_2012-2020_3-7.zip"
+            == "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/AMF_AR-CCa_FLUXNET_2012-2020_v3_r7.zip"
         )
         assert sites[1].site_info.data_hub == "AmeriFlux"
         assert sites[1].site_info.location_lat == -31.4821  # Real value from metadata
         assert sites[1].site_info.location_long == -63.6458  # Real value from metadata
         assert sites[1].site_info.igbp == "GRA"  # Real value from metadata
+        assert sites[1].product_data.product_id == "10.17190/AMF/2571134"  # FLUXNET DOI
 
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_download_links")
-    def test_get_sites_with_unexpected_filename_format(self, mock_get_links, mock_get_metadata):
-        """Test get_sites uses publish_years from grp_publish_fluxnet instead of parsing filename."""
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_citations")
+    def test_get_sites_with_unexpected_filename_format(self, mock_get_citations, mock_get_links, mock_get_metadata):
+        """Test get_sites skips files with invalid filename format."""
         mock_get_metadata.return_value = {
             "US-XYZ": {
+                "site_name": "Test Site XYZ",
                 "grp_location": {"location_lat": "45.0", "location_long": "-90.0"},
                 "grp_igbp": {"igbp": "DBF"},
                 "grp_publish_fluxnet": [2005, 2006, 2007],
@@ -96,19 +111,13 @@ class TestAmeriFluxPlugin:
                 }
             ]
         }
+        mock_get_citations.return_value = {"US-XYZ": "Citation for US-XYZ"}
 
         plugin = ameriflux.AmeriFluxPlugin()
         sites = list(plugin.get_sites())
 
-        assert len(sites) == 1
-        assert sites[0].site_info.site_id == "US-XYZ"
-        assert sites[0].product_data.first_year == 2005  # From publish_years
-        assert sites[0].product_data.last_year == 2007  # From publish_years
-        assert str(sites[0].product_data.download_link) == "http://example.com/US-XYZ_invalidformat.zip"
-        assert sites[0].site_info.data_hub == "AmeriFlux"
-        assert sites[0].site_info.location_lat == 45.0  # From metadata
-        assert sites[0].site_info.location_long == -90.0  # From metadata
-        assert sites[0].site_info.igbp == "DBF"  # From metadata
+        # Sites with invalid filename format should be skipped
+        assert len(sites) == 0
 
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
     def test_get_sites_no_sites_found(self, mock_get_metadata):
@@ -122,15 +131,18 @@ class TestAmeriFluxPlugin:
 
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_download_links")
-    def test_get_sites_partial_failure(self, mock_get_links, mock_get_metadata):
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_citations")
+    def test_get_sites_partial_failure(self, mock_get_citations, mock_get_links, mock_get_metadata):
         """Test get_sites handles partial failures in download link retrieval."""
         mock_get_metadata.return_value = {
             "US-ABC": {
+                "site_name": "Test Site ABC",
                 "grp_location": {"location_lat": "40.0", "location_long": "-100.0"},
                 "grp_igbp": {"igbp": "GRA"},
                 "grp_publish_fluxnet": [2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012],
             },
             "US-DEF": {
+                "site_name": "Test Site DEF",
                 "grp_location": {"location_lat": "41.0", "location_long": "-101.0"},
                 "grp_igbp": {"igbp": "CRO"},
                 "grp_publish_fluxnet": [2010, 2011],
@@ -138,19 +150,18 @@ class TestAmeriFluxPlugin:
         }
         mock_get_links.return_value = {
             "data_urls": [
-                {"site_id": "US-ABC", "url": "http://example.com/US-ABC__FLUXNET_FULLSET_2005-2012_3-7.zip"},
+                {"site_id": "US-ABC", "url": "http://example.com/AMF_US-ABC_FLUXNET_2005-2012_v3_r7.zip"},
                 # Missing entry for US-DEF to simulate failure
             ]
         }
+        mock_get_citations.return_value = {"US-ABC": "Citation for US-ABC"}
 
         plugin = ameriflux.AmeriFluxPlugin()
         sites = list(plugin.get_sites())
 
         assert len(sites) == 1
         assert sites[0].site_info.site_id == "US-ABC"
-        assert (
-            str(sites[0].product_data.download_link) == "http://example.com/US-ABC__FLUXNET_FULLSET_2005-2012_3-7.zip"
-        )
+        assert str(sites[0].product_data.download_link) == "http://example.com/AMF_US-ABC_FLUXNET_2005-2012_v3_r7.zip"
         assert sites[0].site_info.data_hub == "AmeriFlux"
         assert sites[0].site_info.location_lat == 40.0  # From metadata
         assert sites[0].site_info.location_long == -100.0  # From metadata
@@ -172,7 +183,8 @@ class TestAmeriFluxPlugin:
 
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_download_links")
-    def test_get_sites_download_links_failure(self, mock_get_links, mock_get_metadata):
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_citations")
+    def test_get_sites_download_links_failure(self, mock_get_citations, mock_get_links, mock_get_metadata):
         """Test get_sites handles download links API failure gracefully."""
         mock_get_metadata.return_value = {"US-ABC": {"grp_publish_fluxnet": [2005]}}
         mock_get_links.side_effect = Exception("Download links API failure")
@@ -185,7 +197,8 @@ class TestAmeriFluxPlugin:
 
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_download_links")
-    def test_get_sites_with_no_download_links(self, mock_get_links, mock_get_metadata):
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_citations")
+    def test_get_sites_with_no_download_links(self, mock_get_citations, mock_get_links, mock_get_metadata):
         """Test get_sites handles missing download links gracefully."""
         mock_get_metadata.return_value = {"US-XYZ": {"grp_publish_fluxnet": [2005]}}
         # No download links available
@@ -204,13 +217,15 @@ class TestAmeriFluxPlugin:
         mock_response.json.return_value = {
             "values": [
                 {
-                    "site_id": "US-TEST",
+                    "site_id": "US-Tst",
+                    "site_name": "Test Site",
                     "grp_location": {"location_lat": "40.0", "location_long": "-105.0"},
                     "grp_igbp": {"igbp": "ENF"},
                     "grp_publish_fluxnet": [2005, 2006, 2007],
                 },
                 {
                     "site_id": "US-EXM",
+                    "site_name": "Example Site",
                     "grp_location": {"location_lat": "41.0", "location_long": "-106.0"},
                     "grp_igbp": {"igbp": "DBF"},
                     "grp_publish_fluxnet": [2010, 2011, 2012],
@@ -221,9 +236,9 @@ class TestAmeriFluxPlugin:
         mock_request.return_value.__aenter__.return_value = mock_response
 
         metadata = await ameriflux.AmeriFluxPlugin()._get_site_metadata(api_url="http://example.com")
-        assert "US-TEST" in metadata
+        assert "US-Tst" in metadata
         assert "US-EXM" in metadata
-        assert metadata["US-TEST"]["grp_location"]["location_lat"] == "40.0"
+        assert metadata["US-Tst"]["grp_location"]["location_lat"] == "40.0"
 
     @pytest.mark.asyncio
     @patch(
@@ -246,7 +261,7 @@ class TestAmeriFluxPlugin:
     async def test__get_download_links_with_failure(self, mock_request):
         """Test _get_download_links raises PluginError on failure."""
         with pytest.raises(PluginError) as exc_info:
-            await ameriflux.AmeriFluxPlugin()._get_download_links(base_url="http://example.com", site_ids=["US-TEST"])
+            await ameriflux.AmeriFluxPlugin()._get_download_links(base_url="http://example.com", site_ids=["US-Tst"])
 
         assert "ameriflux" in str(exc_info.value).lower()
         assert mock_request.call_count == 1  # Ensure the request was attempted
@@ -261,84 +276,83 @@ class TestAmeriFluxPlugin:
 
         async def mock_json():
             return {
-                "data_urls": [
-                    {"site_id": "US-TEST", "url": "http://example.com/US-TEST__FLUXNET_FULLSET_2005-2012_3-7.zip"}
-                ]
+                "data_urls": [{"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip"}]
             }
 
         mock_response.json = mock_json
 
         links = await ameriflux.AmeriFluxPlugin()._get_download_links(
-            base_url="http://example.com", site_ids=["US-TEST"]
+            base_url="http://example.com", site_ids=["US-Tst"]
         )
         assert links == {
-            "data_urls": [
-                {"site_id": "US-TEST", "url": "http://example.com/US-TEST__FLUXNET_FULLSET_2005-2012_3-7.zip"}
-            ]
+            "data_urls": [{"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip"}]
         }
 
     def test_parse_response_with_invalid_format(self):
         """Test _parse_response method skips invalid entries and continues processing."""
         sample_response = {
             "data_urls": [
-                {"site_id": "US-TEST", "url": "http://example.com/US-TEST__FLUXNET_FULLSET_2005-2012_3-7.zip"},
+                {"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip"},
                 {
                     "site_id": "",
                 },  # Invalid format - missing 'url' key (should be skipped)
             ]
         }
         site_metadata = {
-            "US-TEST": {
+            "US-Tst": {
+                "site_name": "Test Site",
                 "grp_location": {"location_lat": "40.5", "location_long": "-105.5"},
                 "grp_igbp": {"igbp": "ENF"},
                 "grp_publish_fluxnet": [2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012],
             }
         }
+        citations = {"US-Tst": "Citation for US-Tst"}
 
         plugin = ameriflux.AmeriFluxPlugin()
-        results = list(plugin._parse_response(sample_response, site_metadata))
+        results = list(plugin._parse_response(sample_response, site_metadata, citations))
 
         # Should only return valid entries, skipping the invalid one
         assert len(results) == 1
-        assert results[0].site_info.site_id == "US-TEST"
+        assert results[0].site_info.site_id == "US-Tst"
         assert results[0].product_data.first_year == 2005
         assert results[0].product_data.last_year == 2012
-        assert (
-            str(results[0].product_data.download_link)
-            == "http://example.com/US-TEST__FLUXNET_FULLSET_2005-2012_3-7.zip"
-        )
+        assert str(results[0].product_data.download_link) == "http://example.com/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip"
         assert results[0].site_info.data_hub == "AmeriFlux"
 
     def test_parse_response_filters_sites_without_publish_years(self):
-        """Test _parse_response filters out sites with no publish years."""
+        """Test _parse_response filters out sites with no publish years and invalid filenames."""
         sample_response = {
             "data_urls": [
-                {"site_id": "US-TEST", "url": "http://example.com/US-TEST.zip"},
-                {"site_id": "US-NODATA", "url": "http://example.com/US-NODATA.zip"},
+                {"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2005-2007_v1_r0.zip"},
+                {"site_id": "US-NODATA", "url": "http://example.com/AMF_US-NODATA_FLUXNET_2010-2015_v1_r0.zip"},
             ]
         }
         site_metadata = {
-            "US-TEST": {
+            "US-Tst": {
+                "site_name": "Test Site",
                 "grp_location": {"location_lat": "40.5", "location_long": "-105.5"},
                 "grp_igbp": {"igbp": "ENF"},
                 "grp_publish_fluxnet": [2005, 2006, 2007],
             },
             "US-NODATA": {
+                "site_name": "No Data Site",
                 "grp_location": {"location_lat": "41.0", "location_long": "-106.0"},
                 "grp_igbp": {"igbp": "GRA"},
+                # Missing grp_publish_fluxnet - should be filtered out
             },
         }
+        citations = {"US-Tst": "Citation for US-Tst"}
 
         plugin = ameriflux.AmeriFluxPlugin()
-        results = list(plugin._parse_response(sample_response, site_metadata))
+        results = list(plugin._parse_response(sample_response, site_metadata, citations))
 
-        assert len(results) == 1  # Only US-TEST should be included
-        assert results[0].site_info.site_id == "US-TEST"
+        assert len(results) == 1  # Only US-Tst should be included
+        assert results[0].site_info.site_id == "US-Tst"
 
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
     def test_get_sites_no_data_availability(self, mock_get_metadata):
         """Test get_sites returns empty when site has no grp_publish_fluxnet."""
-        mock_get_metadata.return_value = {"US-TEST": {}}
+        mock_get_metadata.return_value = {"US-Tst": {}}
 
         plugin = ameriflux.AmeriFluxPlugin()
         sites = list(plugin.get_sites())
@@ -349,7 +363,7 @@ class TestAmeriFluxPlugin:
     def test_get_sites_all_sites_have_empty_publish_years(self, mock_get_metadata):
         """Test get_sites returns empty when all sites have empty grp_publish_fluxnet."""
         mock_get_metadata.return_value = {
-            "US-TEST": {"grp_publish_fluxnet": []},
+            "US-Tst": {"grp_publish_fluxnet": []},
             "US-EXM": {"grp_publish_fluxnet": []},
         }
 
@@ -362,22 +376,24 @@ class TestAmeriFluxPlugin:
         """Test _parse_response handles invalid lat/lon values gracefully."""
         sample_response = {
             "data_urls": [
-                {"site_id": "US-TEST", "url": "http://example.com/US-TEST.zip"},
+                {"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2005-2006_v1_r0.zip"},
             ]
         }
         site_metadata = {
-            "US-TEST": {
+            "US-Tst": {
+                "site_name": "Test Site",
                 "grp_location": {"location_lat": "invalid", "location_long": "also_invalid"},
                 "grp_igbp": {"igbp": "ENF"},
                 "grp_publish_fluxnet": [2005, 2006],
             }
         }
+        citations = {"US-Tst": "Citation for US-Tst"}
 
         plugin = ameriflux.AmeriFluxPlugin()
-        results = list(plugin._parse_response(sample_response, site_metadata))
+        results = list(plugin._parse_response(sample_response, site_metadata, citations))
 
         assert len(results) == 1
-        assert results[0].site_info.site_id == "US-TEST"
+        assert results[0].site_info.site_id == "US-Tst"
         assert results[0].site_info.location_lat == 0.0  # Fallback value
         assert results[0].site_info.location_long == 0.0  # Fallback value
         assert results[0].site_info.igbp == "ENF"
@@ -387,23 +403,28 @@ class TestAmeriFluxPlugin:
         plugin = ameriflux.AmeriFluxPlugin()
 
         with pytest.raises(ValueError) as exc_info:
-            plugin._build_product_data([], "http://example.com/test.zip")
+            plugin._build_product_data(
+                [], "http://example.com/test.zip", product_id="test-id", citation="test citation", code_version="v1"
+            )
 
         assert "publish_years cannot be empty" in str(exc_info.value)
 
     @pytest.mark.asyncio
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
     @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_download_links")
-    async def test_get_sites_reraises_plugin_error(self, mock_get_links, mock_get_metadata):
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_citations")
+    async def test_get_sites_reraises_plugin_error(self, mock_get_citations, mock_get_links, mock_get_metadata):
         """Test get_sites re-raises PluginError from processing."""
         mock_get_metadata.return_value = {
-            "US-TEST": {
+            "US-Tst": {
+                "site_name": "Test Site",
                 "grp_location": {"location_lat": "40.5", "location_long": "-105.5"},
                 "grp_igbp": {"igbp": "ENF"},
                 "grp_publish_fluxnet": [2020, 2021],
             }
         }
-        mock_get_links.return_value = {"data_urls": [{"site_id": "US-TEST", "url": "http://example.com/test.zip"}]}
+        mock_get_links.return_value = {"data_urls": [{"site_id": "US-Tst", "url": "http://example.com/test.zip"}]}
+        mock_get_citations.return_value = {"US-Tst": "Citation for US-Tst"}
 
         plugin = ameriflux.AmeriFluxPlugin()
 
@@ -414,3 +435,317 @@ class TestAmeriFluxPlugin:
                     pass
 
             assert "ameriflux" in str(exc_info.value).lower()
+
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_download_links")
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_citations")
+    def test_get_sites_with_doi(self, mock_get_citations, mock_get_links, mock_get_metadata):
+        """Test that DOI is properly extracted from site metadata."""
+        mock_get_metadata.return_value = {
+            "US-Ts1": {
+                "site_name": "Test Site 1",
+                "grp_location": {"location_lat": "45.0", "location_long": "-90.0"},
+                "grp_igbp": {"igbp": "DBF"},
+                "grp_publish_fluxnet": [2020, 2021],
+                "doi": {"AmeriFlux": "10.17190/AMF/1234567", "FLUXNET": "10.17190/AMF/7654321"},
+            },
+            "US-Ts2": {
+                "site_name": "Test Site 2",
+                "grp_location": {"location_lat": "40.0", "location_long": "-95.0"},
+                "grp_igbp": {"igbp": "ENF"},
+                "grp_publish_fluxnet": [2020, 2021],
+                "doi": {},  # Empty DOI
+            },
+            "US-Ts3": {
+                "site_name": "Test Site 3",
+                "grp_location": {"location_lat": "35.0", "location_long": "-85.0"},
+                "grp_igbp": {"igbp": "GRA"},
+                "grp_publish_fluxnet": [2020, 2021],
+                # No DOI field at all
+            },
+        }
+        mock_get_links.return_value = {
+            "data_urls": [
+                {"site_id": "US-Ts1", "url": "http://example.com/AMF_US-Ts1_FLUXNET_2010-2012_v1_r0.zip"},
+                {"site_id": "US-Ts2", "url": "http://example.com/AMF_US-Ts2_FLUXNET_2020-2021_v1_r0.zip"},
+                {"site_id": "US-Ts3", "url": "http://example.com/AMF_US-Ts3_FLUXNET_2020-2021_v1_r0.zip"},
+            ]
+        }
+        mock_get_citations.return_value = {
+            "US-Ts1": "Citation for US-Ts1",
+            "US-Ts2": "Citation for US-Ts2",
+            "US-Ts3": "Citation for US-Ts3",
+        }
+
+        plugin = ameriflux.AmeriFluxPlugin()
+        sites = list(plugin.get_sites())
+
+        assert len(sites) == 3
+        # Test site with FLUXNET DOI
+        assert sites[0].site_info.site_id == "US-Ts1"
+        assert sites[0].product_data.product_id == "10.17190/AMF/7654321"
+
+        # Test site with empty DOI dict
+        assert sites[1].site_info.site_id == "US-Ts2"
+        assert sites[1].product_data.product_id == ""
+
+        # Test site with no DOI field
+        assert sites[2].site_info.site_id == "US-Ts3"
+        assert sites[2].product_data.product_id == ""
+
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_download_links")
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_citations")
+    def test_get_sites_with_team_members(self, mock_get_citations, mock_get_links, mock_get_metadata):
+        """Test successful retrieval of sites with team member information."""
+        mock_get_metadata.return_value = {
+            "US-Ha1": {
+                "site_name": "Harvard Forest",
+                "grp_location": {"location_lat": "42.5378", "location_long": "-72.1715"},
+                "grp_igbp": {"igbp": "DBF"},
+                "grp_publish_fluxnet": [2018, 2019, 2020],
+                "doi": {"FLUXNET": "10.17190/AMF/1234567"},
+                "grp_team_member": [
+                    {
+                        "team_member_name": "John Doe",
+                        "team_member_role": "PI",
+                        "team_member_email": "john.doe@harvard.edu",
+                    },
+                    {
+                        "team_member_name": "Jane Smith",
+                        "team_member_role": "Researcher",
+                        "team_member_email": "jane.smith@harvard.edu",
+                    },
+                ],
+            }
+        }
+        mock_get_links.return_value = {
+            "data_urls": [
+                {
+                    "site_id": "US-Ha1",
+                    "url": "https://ftp.fluxdata.org/AMF_US-Ha1_FLUXNET_2018-2020_v1_r0.zip",
+                }
+            ]
+        }
+        mock_get_citations.return_value = {"US-Ha1": "Citation for US-Ha1"}
+
+        plugin = ameriflux.AmeriFluxPlugin()
+        sites = list(plugin.get_sites())
+
+        assert len(sites) == 1
+        assert sites[0].site_info.site_id == "US-Ha1"
+
+        # Verify team members
+        team_members = sites[0].site_info.group_team_member
+        assert len(team_members) == 2
+
+        assert team_members[0].team_member_name == "John Doe"
+        assert team_members[0].team_member_role == "PI"
+        assert team_members[0].team_member_email == "john.doe@harvard.edu"
+
+        assert team_members[1].team_member_name == "Jane Smith"
+        assert team_members[1].team_member_role == "Researcher"
+        assert team_members[1].team_member_email == "jane.smith@harvard.edu"
+
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_download_links")
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_citations")
+    def test_get_sites_with_citations(self, mock_get_citations, mock_get_links, mock_get_metadata):
+        """Test successful retrieval of sites with citation information."""
+        mock_get_metadata.return_value = {
+            "US-Ha1": {
+                "site_name": "Harvard Forest",
+                "grp_location": {"location_lat": "42.5378", "location_long": "-72.1715"},
+                "grp_igbp": {"igbp": "DBF"},
+                "grp_publish_fluxnet": [2018, 2019, 2020],
+                "doi": {"FLUXNET": "10.17190/AMF/1234567"},
+            }
+        }
+        mock_get_links.return_value = {
+            "data_urls": [
+                {
+                    "site_id": "US-Ha1",
+                    "url": "https://ftp.fluxdata.org/AMF_US-Ha1_FLUXNET_2018-2020_v1_r0.zip",
+                }
+            ]
+        }
+        mock_get_citations.return_value = {
+            "US-Ha1": "Munger, J.W., Wofsy, S.C. (2020). AmeriFlux US-Ha1 Harvard Forest..."
+        }
+
+        plugin = ameriflux.AmeriFluxPlugin()
+        sites = list(plugin.get_sites())
+
+        assert len(sites) == 1
+        assert sites[0].site_info.site_id == "US-Ha1"
+        assert (
+            sites[0].product_data.product_citation
+            == "Munger, J.W., Wofsy, S.C. (2020). AmeriFlux US-Ha1 Harvard Forest..."
+        )
+
+    def test_get_sites_skips_sites_without_citations(self, caplog):
+        """Test that sites without citations are skipped and warning is logged."""
+        import logging
+
+        sample_response = {
+            "data_urls": [
+                {
+                    "site_id": "US-Ha1",
+                    "url": "https://ftp.fluxdata.org/AMF_US-Ha1_FLUXNET_2018-2020_v1_r0.zip",
+                },
+                {
+                    "site_id": "US-Nc1",
+                    "url": "https://ftp.fluxdata.org/AMF_US-Nc1_FLUXNET_2020-2021_v1_r0.zip",
+                },
+            ]
+        }
+        site_metadata = {
+            "US-Ha1": {
+                "site_name": "Harvard Forest",
+                "grp_location": {"location_lat": "42.5378", "location_long": "-72.1715"},
+                "grp_igbp": {"igbp": "DBF"},
+                "grp_publish_fluxnet": [2018, 2019, 2020],
+                "doi": {"FLUXNET": "10.17190/AMF/1234567"},
+            },
+            "US-Nc1": {
+                "site_name": "Site Without Citation",
+                "grp_location": {"location_lat": "45.0", "location_long": "-90.0"},
+                "grp_igbp": {"igbp": "ENF"},
+                "grp_publish_fluxnet": [2020, 2021],
+            },
+        }
+        # Only provide citation for one site
+        citations = {"US-Ha1": "Munger, J.W., Wofsy, S.C. (2020). AmeriFlux US-Ha1 Harvard Forest..."}
+
+        plugin = ameriflux.AmeriFluxPlugin()
+
+        # Capture logs from the ameriflux plugin logger
+        with caplog.at_level(logging.WARNING, logger="fluxnet_shuttle.plugins.ameriflux"):
+            # This will exercise the warning log lines 328-332
+            sites = list(plugin._parse_response(sample_response, site_metadata, citations))
+
+        # Only one site should be returned (the one with citation)
+        # Site without citation should be skipped
+        assert len(sites) == 1
+        assert sites[0].site_info.site_id == "US-Ha1"
+
+        # Verify the warning was logged
+        assert "Skipping site US-Nc1 - no citation available" in caplog.text
+        assert "ameriflux-support@lbl.gov" in caplog.text
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.ameriflux.DataHubPlugin._session_request")
+    async def test__get_citations_success(self, mock_request):
+        """Test _get_citations returns expected data on success."""
+        mock_response = MagicMock()
+        mock_request.return_value.__aenter__.return_value = mock_response
+        mock_response.raise_for_status.side_effect = None
+
+        async def mock_json():
+            return {
+                "values": [
+                    {"site_id": "US-Ha1", "citation": "Citation for US-Ha1"},
+                    {"site_id": "US-MMS", "citation": "Citation for US-MMS"},
+                ]
+            }
+
+        mock_response.json = mock_json
+
+        citations = await ameriflux.AmeriFluxPlugin()._get_citations(
+            base_url="http://example.com/", site_ids=["US-Ha1", "US-MMS"]
+        )
+        assert citations == {"US-Ha1": "Citation for US-Ha1", "US-MMS": "Citation for US-MMS"}
+
+    @pytest.mark.asyncio
+    @patch(
+        "fluxnet_shuttle.plugins.ameriflux.DataHubPlugin._session_request",
+        side_effect=PluginError("ameriflux", "Test error"),
+    )
+    async def test__get_citations_failure(self, mock_request):
+        """Test _get_citations handles failure gracefully and returns empty dict."""
+        citations = await ameriflux.AmeriFluxPlugin()._get_citations(
+            base_url="http://example.com/", site_ids=["US-Ha1"]
+        )
+
+        assert citations == {}  # Should return empty dict on failure
+        assert mock_request.call_count == 1  # Ensure the request was attempted
+
+    @pytest.mark.asyncio
+    @patch(
+        "fluxnet_shuttle.plugins.ameriflux.DataHubPlugin._session_request",
+        side_effect=Exception("Generic error"),
+    )
+    async def test__get_citations_generic_exception(self, mock_request):
+        """Test _get_citations handles generic exceptions gracefully."""
+        citations = await ameriflux.AmeriFluxPlugin()._get_citations(
+            base_url="http://example.com/", site_ids=["US-Ha1"]
+        )
+
+        assert citations == {}  # Should return empty dict on generic exception
+        assert mock_request.call_count == 1  # Ensure the request was attempted
+
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_site_metadata")
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_download_links")
+    @patch("fluxnet_shuttle.plugins.ameriflux.AmeriFluxPlugin._get_citations")
+    def test_get_sites_with_invalid_team_member(self, mock_get_citations, mock_get_links, mock_get_metadata, caplog):
+        """Test handling of invalid team member data."""
+        mock_get_metadata.return_value = {
+            "US-Tst": {
+                "site_name": "Test Site",
+                "grp_location": {"location_lat": "45.0", "location_long": "-90.0"},
+                "grp_igbp": {"igbp": "DBF"},
+                "grp_publish_fluxnet": [2020],
+                "grp_team_member": [
+                    {
+                        "team_member_name": "Valid Member",
+                        "team_member_role": "PI",
+                    },
+                    {
+                        # Missing team_member_name - will cause validation error
+                        "team_member_role": "Researcher",
+                    },
+                ],
+            }
+        }
+        mock_get_links.return_value = {
+            "data_urls": [{"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2020-2020_v1_r0.zip"}]
+        }
+        mock_get_citations.return_value = {"US-Tst": "Citation for US-Tst"}
+
+        plugin = ameriflux.AmeriFluxPlugin()
+        with caplog.at_level("WARNING"):
+            sites = list(plugin.get_sites())
+
+        # Should still create site with valid team member only
+        assert len(sites) == 1
+        assert len(sites[0].site_info.group_team_member) == 1
+        assert sites[0].site_info.group_team_member[0].team_member_name == "Valid Member"
+
+        # Check warning was logged for invalid member
+        assert "Error parsing team member for site US-Tst" in caplog.text
+
+    def test_parse_response_logs_debug_for_no_publish_years(self, caplog):
+        """Test that debug logging is triggered when publish years are missing."""
+        sample_response = {
+            "data_urls": [
+                {"site_id": "US-NoY", "url": "http://example.com/AMF_US-NoY_FLUXNET_2020-2021_v1_r0.zip"},
+            ]
+        }
+        site_metadata = {
+            "US-NoY": {
+                "site_name": "No Years Site",
+                "grp_location": {"location_lat": "40.0", "location_long": "-105.0"},
+                "grp_igbp": {"igbp": "ENF"},
+                # grp_publish_fluxnet is missing
+            }
+        }
+
+        plugin = ameriflux.AmeriFluxPlugin()
+        with caplog.at_level("DEBUG", logger="fluxnet_shuttle.plugins.ameriflux"):
+            results = list(plugin._parse_response(sample_response, site_metadata, {}))
+
+        # Should filter out the site
+        assert len(results) == 0
+
+        # Check debug message was logged
+        assert "Skipping site US-NoY - no publish years available" in caplog.text

--- a/tests/test_plugin_icos.py
+++ b/tests/test_plugin_icos.py
@@ -38,11 +38,14 @@ class TestICOSPlugin:
                     {
                         "dobj": {"value": "https://meta.icos-cp.eu/objects/US-ABC"},
                         "station": {"value": "https://meta.icos-cp.eu/stations/US-ABC"},
+                        "stationName": {"value": "Test ICOS Station"},
+                        "fileName": {"value": "FLX_US-ABC_FLUXNET_2021-2021_v1_r0.zip"},
                         "lat": {"value": "12.34"},
                         "lon": {"value": "56.78"},
                         "ecosystemType": {"value": "http://meta.icos-cp.eu/ontologies/cpmeta/igbp_ENF"},
                         "timeStart": {"value": "2021-01-01T00:00:00Z"},
                         "timeEnd": {"value": "2021-12-31T23:59:59Z"},
+                        "citationString": {"value": "Test citation for US-ABC"},
                     }
                 ]
             }
@@ -68,27 +71,36 @@ class TestICOSPlugin:
         assert (
             str(sites[0].product_data.download_link) == "https://data.icos-cp.eu/licence_accept?ids=%5B%22US-ABC%22%5D"
         )
+        # Product ID should be the hashsum (last part of dobj URI)
+        assert sites[0].product_data.product_id == "US-ABC"
+        # Code version should be extracted from filename
+        assert sites[0].product_data.code_version == "v1"
 
     @pytest.mark.asyncio
     @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
     async def test_async_get_sites_with_time_errors(self, mock_request):
         """Test async get_sites method."""
-        mock_response = AsyncMock()
-        mock_response.json.return_value = {
+        # Mock SPARQL response with citation included
+        mock_sparql_response = AsyncMock()
+        mock_sparql_response.json.return_value = {
             "results": {
                 "bindings": [
                     {
                         "dobj": {"value": "https://meta.icos-cp.eu/objects/US-ABC"},
                         "station": {"value": "https://meta.icos-cp.eu/stations/US-ABC"},
+                        "stationName": {"value": "Test Station"},
+                        "fileName": {"value": "FLX_US-ABC_FLUXNET_2000-2020_v1_r0.zip"},
                         "lat": {"value": "12.34"},
                         "lon": {"value": "56.78"},
                         "timeStart": {"value": "BAAR-01-01T00:00:00Z"},
                         "timeEnd": {"value": "FOOO-12-31T23:59:59Z"},
+                        "citationString": {"value": "Test citation for US-ABC"},
                     }
                 ]
             }
         }
-        mock_request.return_value.__aenter__.return_value = mock_response
+
+        mock_request.return_value.__aenter__.return_value = mock_sparql_response
 
         plugin = ICOSPlugin()
 
@@ -109,13 +121,16 @@ class TestICOSPlugin:
         assert (
             str(sites[0].product_data.download_link) == "https://data.icos-cp.eu/licence_accept?ids=%5B%22US-ABC%22%5D"
         )
+        assert sites[0].product_data.product_citation == "Test citation for US-ABC"
 
+        # Now we expect only 1 call for SPARQL (includes team members)
         assert mock_request.call_count == 1
 
     @pytest.mark.asyncio
     @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
     async def test_async_get_sites_with_errors(self, mock_request, caplog):
         """Test async get_sites method with invalid latitude."""
+        # Mock SPARQL response with citation included
         mock_response = AsyncMock()
         mock_response.json.return_value = {
             "results": {
@@ -123,14 +138,18 @@ class TestICOSPlugin:
                     {
                         "dobj": {"value": "https://meta.icos-cp.eu/objects/US-ABC"},
                         "station": {"value": "https://meta.icos-cp.eu/stations/US-ABC"},
+                        "stationName": {"value": "Test Station"},
+                        "fileName": {"value": "FLX_US-ABC_FLUXNET_2023-2023_v1_r0.zip"},
                         "lat": {"value": "12.34ff"},
                         "lon": {"value": "56.78"},
                         "timeStart": {"value": "2023-01-01T00:00:00Z"},
                         "timeEnd": {"value": "2023-12-31T23:59:59Z"},
+                        "citationString": {"value": "Test citation"},
                     }
                 ]
             }
         }
+
         mock_request.return_value.__aenter__.return_value = mock_response
 
         plugin = ICOSPlugin()
@@ -149,6 +168,7 @@ class TestICOSPlugin:
             # Check that warning was logged
             assert "Invalid latitude for station US-ABC" in caplog.text
 
+        # Now we expect only 1 call for SPARQL (includes team members)
         assert mock_request.call_count == 1
 
     def test_ecosystem_to_igbp_mapping(self):
@@ -177,6 +197,7 @@ class TestICOSPlugin:
     @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
     async def test_async_get_sites_with_invalid_longitude(self, mock_request, caplog):
         """Test async get_sites method with invalid longitude."""
+        # Mock SPARQL response with citation included
         mock_response = AsyncMock()
         mock_response.json.return_value = {
             "results": {
@@ -184,14 +205,18 @@ class TestICOSPlugin:
                     {
                         "dobj": {"value": "https://meta.icos-cp.eu/objects/US-XYZ"},
                         "station": {"value": "https://meta.icos-cp.eu/stations/US-XYZ"},
+                        "stationName": {"value": "XYZ Station"},
+                        "fileName": {"value": "FLX_US-XYZ_FLUXNET_2020-2021_v1_r0.zip"},
                         "lat": {"value": "45.5"},
                         "lon": {"value": "invalid_lon"},
                         "timeStart": {"value": "2020-01-01T00:00:00Z"},
                         "timeEnd": {"value": "2021-12-31T23:59:59Z"},
+                        "citationString": {"value": "Test citation"},
                     }
                 ]
             }
         }
+
         mock_request.return_value.__aenter__.return_value = mock_response
 
         plugin = ICOSPlugin()
@@ -210,6 +235,7 @@ class TestICOSPlugin:
             # Check that warning was logged
             assert "Invalid longitude for station US-XYZ" in caplog.text
 
+        # Now we expect only 1 call for SPARQL (includes team members)
         assert mock_request.call_count == 1
 
     @pytest.mark.asyncio
@@ -242,6 +268,257 @@ class TestICOSPlugin:
             assert len(sites) == 0
 
             # Check that warning was logged
-            assert "Error parsing ICOS site data" in caplog.text
+            assert "Error grouping ICOS site data" in caplog.text
+
+        # Now we expect only 1 call for SPARQL (includes team members)
+        assert mock_request.call_count == 1
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
+    async def test_async_get_sites_with_team_members(self, mock_request):
+        """Test async get_sites with team member information."""
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "results": {
+                "bindings": [
+                    {
+                        "dobj": {"value": "https://meta.icos-cp.eu/objects/test123"},
+                        "station": {"value": "https://meta.icos-cp.eu/stations/DE-Hte"},
+                        "stationName": {"value": "Huetelmoor"},
+                        "fileName": {"value": "FLX_DE-Hte_FLUXNET_2009-2018_v1_r0.zip"},
+                        "lat": {"value": "54.21"},
+                        "lon": {"value": "12.18"},
+                        "ecosystemType": {"value": "http://meta.icos-cp.eu/ontologies/cpmeta/igbp_WET"},
+                        "timeStart": {"value": "2009-01-01T00:00:00Z"},
+                        "timeEnd": {"value": "2018-12-31T23:59:59Z"},
+                        "citationString": {"value": "Test citation"},
+                        "firstName": {"value": "Gerald"},
+                        "lastName": {"value": "Jurasinski"},
+                        "email": {"value": "gerald.jurasinski@uni-rostock.de"},
+                        "roleName": {"value": "Principal Investigator"},
+                        "orgName": {"value": "University of Rostock"},
+                    },
+                    {
+                        "dobj": {"value": "https://meta.icos-cp.eu/objects/test123"},
+                        "station": {"value": "https://meta.icos-cp.eu/stations/DE-Hte"},
+                        "stationName": {"value": "Huetelmoor"},
+                        "fileName": {"value": "FLX_DE-Hte_FLUXNET_2009-2018_v1_r0.zip"},
+                        "lat": {"value": "54.21"},
+                        "lon": {"value": "12.18"},
+                        "ecosystemType": {"value": "http://meta.icos-cp.eu/ontologies/cpmeta/igbp_WET"},
+                        "timeStart": {"value": "2009-01-01T00:00:00Z"},
+                        "timeEnd": {"value": "2018-12-31T23:59:59Z"},
+                        "citationString": {"value": "Test citation"},
+                        "firstName": {"value": "Ute"},
+                        "lastName": {"value": "Karstens"},
+                        "email": {"value": "ute.karstens@nateko.lu.se"},
+                        "roleName": {"value": "Researcher"},
+                    },
+                ]
+            }
+        }
+        mock_request.return_value.__aenter__.return_value = mock_response
+
+        plugin = ICOSPlugin()
+        sites = []
+        async for site in plugin.get_sites():
+            sites.append(site)
+
+        assert len(sites) == 1
+        site = sites[0]
+        assert site.site_info.site_id == "DE-Hte"
+        assert site.site_info.site_name == "Huetelmoor"
+        assert site.product_data.code_version == "v1"
+
+        # Verify team members
+        team_members = site.site_info.group_team_member
+        assert len(team_members) == 2
+
+        assert team_members[0].team_member_name == "Gerald Jurasinski"
+        assert team_members[0].team_member_role == "Principal Investigator"
+        assert team_members[0].team_member_email == "gerald.jurasinski@uni-rostock.de"
+
+        assert team_members[1].team_member_name == "Ute Karstens"
+        assert team_members[1].team_member_role == "Researcher"
+        assert team_members[1].team_member_email == "ute.karstens@nateko.lu.se"
 
         assert mock_request.call_count == 1
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
+    async def test_async_get_sites_with_empty_name_team_member(self, mock_request):
+        """Test that team members with only whitespace names are skipped."""
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "results": {
+                "bindings": [
+                    {
+                        "dobj": {"value": "https://meta.icos-cp.eu/objects/test123"},
+                        "station": {"value": "https://meta.icos-cp.eu/stations/DE-Hte"},
+                        "stationName": {"value": "Huetelmoor"},
+                        "fileName": {"value": "FLX_DE-Hte_FLUXNET_2009-2018_v1_r0.zip"},
+                        "lat": {"value": "54.21"},
+                        "lon": {"value": "12.18"},
+                        "timeStart": {"value": "2009-01-01T00:00:00Z"},
+                        "timeEnd": {"value": "2018-12-31T23:59:59Z"},
+                        "citationString": {"value": "Test citation for DE-Hte"},
+                        "firstName": {"value": "   "},
+                        "lastName": {"value": "   "},
+                        "roleName": {"value": "PI"},
+                    }
+                ]
+            }
+        }
+        mock_request.return_value.__aenter__.return_value = mock_response
+
+        plugin = ICOSPlugin()
+        sites = []
+        async for site in plugin.get_sites():
+            sites.append(site)
+
+        # Site should be created but with no team members (empty names filtered out)
+        assert len(sites) == 1
+        assert len(sites[0].site_info.group_team_member) == 0
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
+    async def test_async_get_sites_error_parsing_site_data(self, mock_request, caplog):
+        """Test error handling when parsing site data fails."""
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "results": {
+                "bindings": [
+                    {
+                        "dobj": {"value": "https://meta.icos-cp.eu/objects/test123"},
+                        "station": {"value": "https://meta.icos-cp.eu/stations/DE-Hte"},
+                        "stationName": {"value": "Huetelmoor"},
+                        "fileName": {"value": "FLX_DE-Hte_FLUXNET_2009-2018_v1_r0.zip"},
+                        "lat": {"value": "invalid"},  # This will cause error in float conversion
+                        "lon": {"value": "12.18"},
+                        "citationString": {"value": "Test citation for DE-Hte"},
+                        # Missing required timeStart and timeEnd will use defaults
+                    }
+                ]
+            }
+        }
+        mock_request.return_value.__aenter__.return_value = mock_response
+
+        plugin = ICOSPlugin()
+        with caplog.at_level("WARNING"):
+            sites = []
+            async for site in plugin.get_sites():
+                sites.append(site)
+
+        # Site should still be created with fallback values
+        assert len(sites) == 1
+        # Should have warning about invalid latitude
+        assert "Invalid latitude for station DE-Hte" in caplog.text
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
+    async def test_async_get_sites_exception_in_metadata_creation(self, mock_request, caplog):
+        """Test error handling when filename validation fails due to missing fileName field."""
+        mock_response = AsyncMock()
+        # Provide incomplete data without fileName field - will be skipped by validation
+        mock_response.json.return_value = {
+            "results": {
+                "bindings": [
+                    {
+                        "dobj": {"value": "https://meta.icos-cp.eu/objects/test123"},
+                        "station": {"value": "https://meta.icos-cp.eu/stations/"},  # Invalid - too short
+                        # Missing fileName field - will be skipped by validation
+                    }
+                ]
+            }
+        }
+        mock_request.return_value.__aenter__.return_value = mock_response
+
+        plugin = ICOSPlugin()
+        with caplog.at_level("INFO"):
+            sites = []
+            async for site in plugin.get_sites():
+                sites.append(site)
+
+        # Should skip site due to missing fileName field
+        assert len(sites) == 0
+        # Should log info about filename validation failure
+        assert (
+            "filename does not follow standard format" in caplog.text or "Error grouping ICOS site data" in caplog.text
+        )
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
+    async def test_async_get_sites_missing_citation(self, mock_request, caplog):
+        """Test that sites without citations are skipped with a helpful warning."""
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "results": {
+                "bindings": [
+                    {
+                        "dobj": {"value": "https://meta.icos-cp.eu/objects/test123"},
+                        "station": {"value": "https://meta.icos-cp.eu/stations/DE-Tst"},
+                        "stationName": {"value": "Test Site"},
+                        "fileName": {"value": "FLX_DE-Tst_FLUXNET_2020-2021_v1_r0.zip"},
+                        "lat": {"value": "50.5"},
+                        "lon": {"value": "12.18"},
+                        "timeStart": {"value": "2020-01-01"},
+                        "timeEnd": {"value": "2021-12-31"},
+                        # Missing citationString - should trigger skip
+                    }
+                ]
+            }
+        }
+        mock_request.return_value.__aenter__.return_value = mock_response
+
+        plugin = ICOSPlugin()
+        # Capture logs from the ICOS plugin logger
+        with caplog.at_level("WARNING", logger="fluxnet_shuttle.plugins.icos"):
+            sites = []
+            async for site in plugin.get_sites():
+                sites.append(site)
+
+        # Should skip the site
+        assert len(sites) == 0
+        # Should log warning about missing citation (lines 271-276)
+        assert "Skipping site DE-Tst - no citation available" in caplog.text
+        assert "support@fluxnet.org" in caplog.text
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
+    @patch("fluxnet_shuttle.plugins.icos.FluxnetDatasetMetadata")
+    async def test_async_get_sites_generic_exception_handling(self, mock_metadata_class, mock_request, caplog):
+        """Test generic exception handling in _parse_sparql_response when FluxnetDatasetMetadata creation fails."""
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "results": {
+                "bindings": [
+                    {
+                        "dobj": {"value": "https://meta.icos-cp.eu/objects/test123"},
+                        "station": {"value": "https://meta.icos-cp.eu/stations/DE-Tst"},
+                        "stationName": {"value": "Test Site"},
+                        "fileName": {"value": "FLX_DE-Tst_FLUXNET_2020-2021_v1_r0.zip"},
+                        "lat": {"value": "50.5"},
+                        "lon": {"value": "12.18"},
+                        "timeStart": {"value": "2020-01-01"},
+                        "timeEnd": {"value": "2021-12-31"},
+                        "citationString": {"value": "Test citation for DE-Tst"},
+                    }
+                ]
+            }
+        }
+        mock_request.return_value.__aenter__.return_value = mock_response
+
+        # Make FluxnetDatasetMetadata raise an unexpected exception
+        mock_metadata_class.side_effect = RuntimeError("Unexpected error during metadata creation")
+
+        plugin = ICOSPlugin()
+        with caplog.at_level("WARNING"):
+            sites = []
+            async for site in plugin.get_sites():
+                sites.append(site)
+
+        # Should catch the exception and continue
+        assert len(sites) == 0
+        # Should log warning about parsing error
+        assert "Error parsing ICOS site data" in caplog.text
+        assert "Unexpected error during metadata creation" in caplog.text

--- a/tests/test_shuttle.py
+++ b/tests/test_shuttle.py
@@ -12,7 +12,9 @@ from fluxnet_shuttle.shuttle import (
     _extract_filename_from_headers,
     _extract_filename_from_url,
     download,
+    extract_code_version_from_filename,
     listall,
+    validate_fluxnet_filename_format,
 )
 
 
@@ -91,6 +93,77 @@ class TestExtractFilenameFromHeaders:
         headers = {"Content-Disposition": "attachment"}
         result = _extract_filename_from_headers(headers)
         assert result is None
+
+
+class TestExtractCodeVersionFromFilename:
+    """Test cases for the extract_code_version_from_filename function."""
+
+    def test_valid_zip_format(self):
+        """Test extracting version from valid ZIP filename."""
+        filename = "AMF_US-Ha1_FLUXNET_2005-2012_v3_r7.zip"
+        result = extract_code_version_from_filename(filename)
+        assert result == "v3"
+
+    def test_valid_zip_format_with_url(self):
+        """Test extracting version from full URL with ZIP file."""
+        url = "https://example.com/AMF_AR-Bal_FLUXNET_2012-2013_v3_r7.zip"
+        result = extract_code_version_from_filename(url)
+        assert result == "v3"
+
+    def test_valid_zip_format_different_version(self):
+        """Test extracting different version number."""
+        filename = "AMF_IT-Niv_FLUXNET_2010-2015_v1_r0.zip"
+        result = extract_code_version_from_filename(filename)
+        assert result == "v1"
+
+    def test_invalid_filename_format(self):
+        """Test with filename that doesn't match pattern."""
+        filename = "invalid_filename.zip"
+        result = extract_code_version_from_filename(filename)
+        assert result == ""
+
+    def test_empty_filename(self):
+        """Test with empty filename."""
+        result = extract_code_version_from_filename("")
+        assert result == ""
+
+    def test_none_filename(self):
+        """Test with None filename."""
+        result = extract_code_version_from_filename(None)
+        assert result == ""
+
+
+class TestValidateFluxnetFilenameFormat:
+    """Test cases for the validate_fluxnet_filename_format function."""
+
+    def test_valid_ameriflux_format(self):
+        """Test valid AmeriFlux filename format."""
+        filename = "AMF_US-Ha1_FLUXNET_2005-2012_v3_r7.zip"
+        assert validate_fluxnet_filename_format(filename) is True
+
+    def test_valid_icos_format(self):
+        """Test valid ICOS filename format."""
+        filename = "FLX_DE-Hte_FLUXNET_2009-2018_v1_r0.zip"
+        assert validate_fluxnet_filename_format(filename) is True
+
+    def test_valid_format_with_url(self):
+        """Test valid filename within URL."""
+        url = "https://example.com/AMF_AR-Bal_FLUXNET_2012-2013_v3_r7.zip"
+        assert validate_fluxnet_filename_format(url) is True
+
+    def test_invalid_format(self):
+        """Test invalid filename format."""
+        filename = "invalid_filename.zip"
+        assert validate_fluxnet_filename_format(filename) is False
+
+    def test_empty_filename(self):
+        """Test empty filename."""
+        assert validate_fluxnet_filename_format("") is False
+
+    def test_partial_format(self):
+        """Test filename with partial format."""
+        filename = "US-Ha1_FLUXNET_2005-2012.zip"
+        assert validate_fluxnet_filename_format(filename) is False
 
 
 class TestDownloadDataset:
@@ -413,27 +486,71 @@ class TestListall:
             MagicMock(
                 site_info=MagicMock(
                     site_id="US-TEST",
+                    site_name="Test Site",
                     data_hub="AmeriFlux",
                     location_lat=45.0,
                     location_long=-120.0,
+                    igbp="DBF",
+                    group_team_member=[],
+                    model_dump=lambda exclude=None: {
+                        "site_id": "US-TEST",
+                        "site_name": "Test Site",
+                        "data_hub": "AmeriFlux",
+                        "location_lat": 45.0,
+                        "location_long": -120.0,
+                        "igbp": "DBF",
+                    },
                 ),
                 product_data=MagicMock(
                     first_year=2000,
                     last_year=2020,
                     download_link="http://example.com/test.zip",
+                    product_citation="Test citation",
+                    product_id="test-id",
+                    code_version="v1",
+                    model_dump=lambda: {
+                        "first_year": 2000,
+                        "last_year": 2020,
+                        "download_link": "http://example.com/test.zip",
+                        "product_citation": "Test citation",
+                        "product_id": "test-id",
+                        "code_version": "v1",
+                    },
                 ),
             ),
             MagicMock(
                 site_info=MagicMock(
                     site_id="FI-HYY",
+                    site_name="Hyytiälä",
                     data_hub="ICOS",
                     location_lat=61.85,
                     location_long=24.29,
+                    igbp="ENF",
+                    group_team_member=[],
+                    model_dump=lambda exclude=None: {
+                        "site_id": "FI-HYY",
+                        "site_name": "Hyytiälä",
+                        "data_hub": "ICOS",
+                        "location_lat": 61.85,
+                        "location_long": 24.29,
+                        "igbp": "ENF",
+                    },
                 ),
                 product_data=MagicMock(
                     first_year=2005,
                     last_year=2018,
                     download_link="http://example.com/icos.zip",
+                    product_citation="ICOS citation",
+                    product_id="icos-id",
+                    code_version="v2",
+                    model_dump=lambda: {
+                        "first_year": 2005,
+                        "last_year": 2018,
+                        "download_link": "http://example.com/icos.zip",
+                        "product_citation": "ICOS citation",
+                        "product_id": "icos-id",
+                        "code_version": "v2",
+                    },
                 ),
             ),
         }


### PR DESCRIPTION
Resolves #37, #39

This PR adds comprehensive support for tracking ONEFlux code versions, team member information, and citation data across all FLUXNET data hubs.

Changes:
- Add code_version field to DataFluxnetProduct model
- Add TeamMember model and group_team_member field to BadmSiteGeneralInfo
- Add product_citation and product_id fields to DataFluxnetProduct
- Implement citation retrieval for AmeriFlux sites via v2 API
- Add citation validation for both ICOS and AmeriFlux plugins
- Add extract_code_version_from_filename() utility function
- Add validate_fluxnet_filename_format() utility function
- Update ICOS plugin to extract citations from SPARQL query
- Update ICOS plugin to extract team member information
- Skip sites without citations with helpful warning messages
- Add additional fields to snapshot file

Technical details:
- Citations are now required fields validated by Pydantic models
- Sites missing citations are skipped with warnings directing users to support
- AmeriFlux citations fetched from /citation/AmeriFlux/{site_id} endpoint
- ICOS citations retrieved via SPARQL query (cpmeta:hasCitationString)
- Team members extracted from SPARQL membership data for ICOS sites
- Code version extracted from standard FLUXNET filename format
- Comprehensive test coverage for all new functionality

Contact information:
- AmeriFlux issues: ameriflux-support@lbl.gov
- ICOS issues: support@fluxnet.org