### PR TITLE
refactor: rename NetworkPlugin to DataHubPlugin for clearer terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ![CI](https://github.com/AMF-FLX/fluxnet-shuttle-lib/actions/workflows/python-ci.yml/badge.svg)
 
-A Python library for FLUXNET shuttle operations providing functionality for downloading and cataloging FLUXNET data from multiple networks including AmeriFlux, ICOS, and FLUXNET2015.
+A Python library for FLUXNET shuttle operations providing functionality for downloading and cataloging FLUXNET data from multiple data hubs including AmeriFlux, ICOS, and FLUXNET2015.
 
 ## Features
-- **Data Download**: Download FLUXNET data from AmeriFlux and ICOS networks
-- **Data Catalog**: List available datasets from multiple FLUXNET networks
+- **Data Download**: Download FLUXNET data from AmeriFlux and ICOS data hubs
+- **Data Catalog**: List available datasets from multiple FLUXNET data hubs
 - **Command Line Interface**: Easy-to-use CLI tool `fluxnet-shuttle` for common operations
-- **Network Support**: 
+- **Integrated Data Hubs**:
   - AmeriFlux (via AmeriFlux API)
   - ICOS (via ICOS Carbon Portal)
   - FLUXNET2015 (placeholder for future implementation)
@@ -76,7 +76,7 @@ Discover and catalog all available FLUXNET datasets:
 ```bash
 fluxnet-shuttle listall --verbose
 ```
-- Queries both AmeriFlux and ICOS networks
+- Queries both AmeriFlux and ICOS data hubs
 - Creates a timestamped CSV file with download information
 - Takes 1-2 minutes to complete due to API processing time
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -19,7 +19,7 @@ Commands
 listall
 ~~~~~~~
 
-List all available FLUXNET datasets from AmeriFlux and ICOS networks. Creates a snapshot CSV file containing available site metadata and download links. The timestamp of the request is included in the filename.
+List all available FLUXNET datasets from AmeriFlux and ICOS data hubs. Creates a snapshot CSV file containing available site metadata and download links. The timestamp of the request is included in the filename.
 
 .. code-block:: bash
 
@@ -33,7 +33,7 @@ List all available FLUXNET datasets from AmeriFlux and ICOS networks. Creates a 
 
 Creates a file named ``fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv`` containing:
 
-- Network name
+- Data hub name
 - Site ID
 - First year of data
 - Last year of data
@@ -92,24 +92,24 @@ Download FLUXNET data products (zip files) for specified sites using a snapshot 
     # Download ALL sites without confirmation (automation)
     fluxnet-shuttle download -f fluxnet_shuttle_snapshot_20251114T113216.csv --quiet
 
-sources
-~~~~~~~
+listdatahubs
+~~~~~~~~~~~~
 
-List available FLUXNET network plugins dynamically registered in the system.
+List available FLUXNET data hub plugins dynamically registered in the system.
 
 .. code-block:: bash
 
-    fluxnet-shuttle sources
+    fluxnet-shuttle listdatahubs
 
 **Output:**
 
-Displays all registered network plugins with their display names and identifiers.
+Displays all registered data hub plugins with their display names and identifiers.
 
 **Example:**
 
 .. code-block:: bash
 
-    fluxnet-shuttle sources
+    fluxnet-shuttle listdatahubs
     # Output:
     #   - AmeriFlux (ameriflux)
     #   - ICOS (icos)
@@ -132,8 +132,8 @@ Complete workflow from discovery to download:
 
 .. code-block:: bash
 
-    # Step 1: Check available network plugins
-    fluxnet-shuttle sources
+    # Step 1: Check available data hub plugins
+    fluxnet-shuttle listdatahubs
 
     # Step 2: Create directories for snapshots and downloads
     mkdir /data/snapshots /data/fluxnet

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -6,20 +6,20 @@ This guide covers advanced usage of the FLUXNET Shuttle Library's core API, incl
 Overview
 --------
 
-The FLUXNET Shuttle Library uses a plugin-based architecture where each FLUXNET network is implemented as a plugin. The core API provides direct access to these plugins and the orchestrator that coordinates them.
+The FLUXNET Shuttle Library uses a plugin-based architecture where each FLUXNET data hub is implemented as a plugin. The core API provides direct access to these plugins and the orchestrator that coordinates them.
 
 Key Components
 ~~~~~~~~~~~~~~
 
-- **FluxnetShuttle**: Main orchestrator that coordinates multiple network plugins
-- **NetworkPlugin**: Abstract base class for network-specific implementations
+- **FluxnetShuttle**: Main orchestrator that coordinates multiple data hub plugins
+- **DataHubPlugin**: Abstract base class for data hub-specific implementations
 - **PluginRegistry**: Manages plugin registration and instantiation
 - **ErrorCollectingIterator**: Async iterator that collects errors while continuing to yield results
 
 Using FluxnetShuttle
 --------------------
 
-The ``FluxnetShuttle`` class provides an interface for working with multiple network plugins simultaneously.
+The ``FluxnetShuttle`` class provides an interface for working with multiple data hub plugins simultaneously.
 
 Basic Usage
 ~~~~~~~~~~~
@@ -31,7 +31,7 @@ Basic Usage
     # Create shuttle instance (automatically loads all registered plugins)
     shuttle = FluxnetShuttle()
 
-    # Fetch data from all networks asynchronously
+    # Fetch data from all data hubs asynchronously
     sites = []
     for site in shuttle.get_all_sites():
         sites.append(site)
@@ -54,7 +54,7 @@ Programmatic Error Handling
     # Create shuttle instance
     shuttle = FluxnetShuttle()
 
-    # Fetch data from all networks
+    # Fetch data from all data hubs
     sites = []
     for site in shuttle.get_all_sites():
         sites.append(site)
@@ -67,7 +67,7 @@ Programmatic Error Handling
 
     # Access detailed error information
     for error in error_summary.errors:
-        print(f"Network: {error.network}")
+        print(f"Data Hub: {error.data_hub}")
         print(f"Operation: {error.operation}")
         print(f"Error: {error.error}")
         print(f"Timestamp: {error.timestamp}")
@@ -76,12 +76,12 @@ The `ErrorSummary` model includes:
 
 - `total_errors` (int): Total number of errors encountered
 - `total_results` (int): Total number of successful results retrieved
-- `errors` (List[PluginErrorDetail]): Detailed error information with network, operation, error message, and ISO timestamp
+- `errors` (List[PluginErrorDetail]): Detailed error information with data hub, operation, error message, and ISO timestamp
 
 Working with Individual Plugins
 --------------------------------
 
-You can also work with individual network plugins directly:
+You can also work with individual data hub plugins directly:
 
 .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,15 +5,15 @@ Welcome to FLUXNET Shuttle Library's documentation!
 
 FLUXNET Shuttle Library is a Python library for FLUXNET shuttle operations providing
 functionality for discovering, downloading, and cataloging FLUXNET data from multiple
-networks including AmeriFlux, ICOS, and FLUXNET2015.
+data hubs including AmeriFlux, ICOS, and FLUXNET2015.
 
 Features
 --------
 
-- **Data Download**: Download FLUXNET data from AmeriFlux and ICOS networks
-- **Data Catalog**: List available datasets from multiple FLUXNET networks  
+- **Data Download**: Download FLUXNET data from AmeriFlux and ICOS data hubs
+- **Data Catalog**: List available datasets from multiple FLUXNET data hubs  
 - **Command Line Interface**: Easy-to-use CLI tool ``fluxnet-shuttle`` for common operations
-- **Network Support**: AmeriFlux (via AmeriFlux API), ICOS (via ICOS Carbon Portal), FLUXNET2015 (placeholder)
+- **Integrated Data Hubs**: AmeriFlux (via AmeriFlux API), ICOS (via ICOS Carbon Portal), FLUXNET2015 (placeholder)
 - **Comprehensive Logging**: Configurable logging with multiple outputs
 - **Error Handling**: Custom exception handling for FLUXNET operations
 - **Type Safety**: Full type hints for better development experience

--- a/src/fluxnet_shuttle/__init__.py
+++ b/src/fluxnet_shuttle/__init__.py
@@ -11,10 +11,10 @@
 
 
 FLUXNET Shuttle Library provides functionality for discovering, downloading, and cataloging
-FLUXNET data from multiple networks including AmeriFlux, ICOS, and FLUXNET2015.
+FLUXNET data from multiple data hubs including AmeriFlux, ICOS, and FLUXNET2015.
 
 The library offers both synchronous and asynchronous Python APIs with a plugin-based
-architecture for extending to new FLUXNET networks.
+architecture for extending to new FLUXNET data hubs.
 
 *Features*
 

--- a/src/fluxnet_shuttle/core/base.py
+++ b/src/fluxnet_shuttle/core/base.py
@@ -3,23 +3,23 @@ Base Plugin Interface
 =====================
 
 :module: fluxnet_shuttle.core.base
-:synopsis: Base class and interfaces for network plugins in the FLUXNET Shuttle library.
+:synopsis: Base class and interfaces for data hub plugins in the FLUXNET Shuttle library.
 :author: Valerie Hendrix <vchendrix@lbl.gov>
 :platform: Unix, Windows
 :created: 2025-10-09
 
 .. currentmodule:: fluxnet_shuttle.core.base
 
-This module defines the base class and interfaces for network plugins
+This module defines the base class and interfaces for data hub plugins
 in the FLUXNET Shuttle library.
 
-Network Plugin Implementation
-+++++++++++++++++++++++++++++
+Data Hub Plugin Implementation
+++++++++++++++++++++++++++++++
 
-The :class:`NetworkPlugin` abstract base class provides the interface
-that all network plugins must implement. It includes methods for
+The :class:`DataHubPlugin` abstract base class provides the interface
+that all data hub plugins must implement. It includes methods for
 retrieving site metadata and handling HTTP requests. When implementing
-a new network plugin, developers should subclass :class:`NetworkPlugin`
+a new data hub plugin, developers should subclass :class:`DataHubPlugin`
 and provide concrete implementations for the abstract methods.
 
 The :property name must return a unique identifier for the plugin, while the
@@ -30,33 +30,33 @@ available through the :func:`async_to_sync_generator` decorator.
 
 Implementation Basics
 ---------------------
-An example implementation of a network plugin might look like this::
+An example implementation of a data hub plugin might look like this::
 
-    from fluxnet_shuttle.core.base import NetworkPlugin
+    from fluxnet_shuttle.core.base import DataHubPlugin
     from fluxnet_shuttle.models import FluxnetDatasetMetadata
 
-    class MyNetworkPlugin(NetworkPlugin):
+    class MyDataHubPlugin(DataHubPlugin):
         @property
         def name(self) -> str:
-            return "mynetwork"
+            return "mydatahub"
 
         @property
         def display_name(self) -> str:
-            return "My Network"
+            return "My Data Hub"
 
     @async_to_sync_generator
     async def get_sites(self, **filters) -> AsyncGenerator[FluxnetDatasetMetadata, None]:
         # Implementation to fetch and yield site metadata
-        async with self._session_request("GET", "https://api.mynetwork.org/sites") as response:
+        async with self._session_request("GET", "https://api.mydatahub.org/sites") as response:
             data = await response.json()
             for site in data["sites"]:
                 yield FluxnetDatasetMetadata(...)  # Populate with actual data
 
 
 Each plugin must implement the abstract methods defined in the
-:class:`NetworkPlugin` base class.
+:class:`DataHubPlugin` base class.
 
-The :class:`NetworkPlugin` class provides both asynchronous and synchronous
+The :class:`DataHubPlugin` class provides both asynchronous and synchronous
 versions of the primary method for retrieving site metadata. The asynchronous
 version is defined as :func:`get_sites`, which is an async generator method.
 
@@ -94,11 +94,11 @@ from ..models import FluxnetDatasetMetadata
 _logger = logging.getLogger(__name__)
 
 
-class NetworkPlugin(ABC):
+class DataHubPlugin(ABC):
     """
-    Base class for all network plugins.
+    Base class for all data hub plugins.
 
-    This abstract base class defines the interface that all network plugins
+    This abstract base class defines the interface that all data hub plugins
     must implement. It provides both async and sync versions of the get_sites
     method through the sync_from_async decorator.
 
@@ -108,7 +108,7 @@ class NetworkPlugin(ABC):
 
     def __init__(self, config: Optional[Dict[str, Any]] = None):
         """
-        Initialize the network plugin.
+        Initialize the data hub plugin.
 
         Args:
             config: Optional configuration dictionary
@@ -118,10 +118,10 @@ class NetworkPlugin(ABC):
     @property
     def name(self) -> str:  # pragma: no cover
         """
-        Network name identifier.
+        Data hub name identifier.
 
         Returns:
-            str: Lowercase network identifier (e.g., 'ameriflux', 'icos')
+            str: Lowercase data hub identifier (e.g., 'ameriflux', 'icos')
         """
         raise NotImplementedError("Subclasses must implement the 'name' property")
 
@@ -129,10 +129,10 @@ class NetworkPlugin(ABC):
     @abstractmethod
     def display_name(self) -> str:
         """
-        Human-readable network name.
+        Human-readable data hub name.
 
         Returns:
-            str: Display name for the network (e.g., 'AmeriFlux', 'ICOS')
+            str: Display name for the data hub (e.g., 'AmeriFlux', 'ICOS')
         """
         pass
 
@@ -140,7 +140,7 @@ class NetworkPlugin(ABC):
     @abstractmethod
     async def get_sites(self, **filters) -> AsyncGenerator[FluxnetDatasetMetadata, None]:
         """
-        Get available sites from the network.
+        Get available sites from the data hub.
 
         This is the primary method that plugins must implement.
         A synchronous version is automatically available as get_sites_sync().
@@ -155,7 +155,7 @@ class NetworkPlugin(ABC):
             PluginError: If a shuttle plugin error occurs during site retrieval
 
         Example:
-            >>> plugin = SomeNetworkPlugin()
+            >>> plugin = SomeDataHubPlugin()
             >>> async for site in plugin.get_sites():
             ...     print(site.site_info.site_id)
 

--- a/src/fluxnet_shuttle/core/config.py
+++ b/src/fluxnet_shuttle/core/config.py
@@ -26,8 +26,8 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class NetworkConfig:
-    """Configuration for a specific network."""
+class DataHubConfig:
+    """Configuration for a specific data hub."""
 
     enabled: bool = True
 
@@ -36,7 +36,7 @@ class NetworkConfig:
 class ShuttleConfig:
     """Main shuttle configuration."""
 
-    networks: Dict[str, NetworkConfig] = field(default_factory=dict)
+    data_hubs: Dict[str, DataHubConfig] = field(default_factory=dict)
     parallel_requests: int = 2
 
     @classmethod
@@ -69,13 +69,13 @@ class ShuttleConfig:
 
             # Parse configuration
             config = cls()
-            if "networks" in config_dict:
-                for network_name, network_data in config_dict["networks"].items():
-                    config.networks[network_name] = NetworkConfig(**network_data)
+            if "data_hubs" in config_dict:
+                for data_hub_name, data_hub_data in config_dict["data_hubs"].items():
+                    config.data_hubs[data_hub_name] = DataHubConfig(**data_hub_data)
 
             # Update other settings
             for key, value in config_dict.items():
-                if key != "networks" and hasattr(config, key):
+                if key != "data_hubs" and hasattr(config, key):
                     setattr(config, key, value)
 
             return config
@@ -106,12 +106,12 @@ class ShuttleConfig:
             # Start with default config and override with file config
             config = cls.load_default()
 
-            if "networks" in config_dict:
-                for network_name, network_data in config_dict["networks"].items():
-                    config.networks[network_name] = NetworkConfig(**network_data)
+            if "data_hubs" in config_dict:
+                for data_hub_name, data_hub_data in config_dict["data_hubs"].items():
+                    config.data_hubs[data_hub_name] = DataHubConfig(**data_hub_data)
 
             for key, value in config_dict.items():
-                if key != "networks" and hasattr(config, key):
+                if key != "data_hubs" and hasattr(config, key):
                     setattr(config, key, value)
 
             logger.info(f"Loaded configuration from {config_path}")
@@ -126,7 +126,7 @@ class ShuttleConfig:
         """Get hardcoded default configuration."""
         return {
             "parallel_requests": 2,
-            "networks": {
+            "data_hubs": {
                 "ameriflux": {"enabled": True},
                 "icos": {"enabled": True},
                 "fluxnet2015": {"enabled": False},
@@ -139,11 +139,11 @@ class ShuttleConfig:
         config_dict = cls._get_hardcoded_defaults()
         config = cls()
 
-        for network_name, network_data in config_dict["networks"].items():
-            config.networks[network_name] = NetworkConfig(**network_data)
+        for data_hub_name, data_hub_data in config_dict["data_hubs"].items():
+            config.data_hubs[data_hub_name] = DataHubConfig(**data_hub_data)
 
         for key, value in config_dict.items():
-            if key != "networks" and hasattr(config, key):
+            if key != "data_hubs" and hasattr(config, key):
                 setattr(config, key, value)
 
         return config

--- a/src/fluxnet_shuttle/core/exceptions.py
+++ b/src/fluxnet_shuttle/core/exceptions.py
@@ -40,6 +40,6 @@ class ConfigurationError(FLUXNETShuttleError):
 
 
 class NetworkError(PluginError):
-    """Exception raised when there's a network-related issue."""
+    """Exception raised when there's a connectivity issue."""
 
     pass

--- a/src/fluxnet_shuttle/core/registry.py
+++ b/src/fluxnet_shuttle/core/registry.py
@@ -11,7 +11,7 @@ Plugin Registry and Error Collection
 .. currentmodule:: fluxnet_shuttle.core.registry
 
 
-This module provides the plugin registry for managing network plugins
+This module provides the plugin registry for managing data hub plugins
 and error collection capabilities.
 """
 
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import AsyncGenerator, Dict, List, Type
 
 from ..models import ErrorSummary, FluxnetDatasetMetadata, PluginErrorDetail
-from .base import NetworkPlugin
+from .base import DataHubPlugin
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ class ErrorCollectingIterator:
     from multiple plugins while isolating and collecting any errors that occur.
     """
 
-    def __init__(self, plugins: Dict[str, NetworkPlugin], operation: str, **kwargs):
+    def __init__(self, plugins: Dict[str, DataHubPlugin], operation: str, **kwargs):
         """
         Initialize the error collecting iterator.
 
@@ -166,7 +166,7 @@ class ErrorCollectingIterator:
         """
         error_details = [
             PluginErrorDetail(
-                network=error.plugin_name,
+                data_hub=error.plugin_name,
                 operation=error.operation,
                 error=str(error.error),
                 timestamp=error.timestamp.isoformat(),
@@ -183,26 +183,26 @@ class ErrorCollectingIterator:
 
 class PluginRegistry:
     """
-    Registry for managing network plugins with automatic discovery.
+    Registry for managing data hub plugins with automatic discovery.
 
-    This class manages the registration and instantiation of network plugins,
+    This class manages the registration and instantiation of data hub plugins,
     including automatic discovery through entry points.
     """
 
     def __init__(self):
         """Initialize the plugin registry."""
-        self._plugins: Dict[str, Type[NetworkPlugin]] = {}
-        self._instances: Dict[str, NetworkPlugin] = {}
+        self._plugins: Dict[str, Type[DataHubPlugin]] = {}
+        self._instances: Dict[str, DataHubPlugin] = {}
 
-    def register(self, plugin_class: Type[NetworkPlugin]) -> None:
+    def register(self, plugin_class: Type[DataHubPlugin]) -> None:
         """
-        Register a network plugin.
+        Register a data hub plugin.
 
         Args:
             plugin_class: The plugin class to register
         """
-        if not issubclass(plugin_class, NetworkPlugin):
-            raise TypeError("Plugin class must inherit from NetworkPlugin")
+        if not issubclass(plugin_class, DataHubPlugin):
+            raise TypeError("Plugin class must inherit from DataHubPlugin")
 
         # Check for duplicate names
         temp_instance = plugin_class()
@@ -216,7 +216,7 @@ class PluginRegistry:
         self._plugins[plugin_name] = plugin_class
         logger.debug(f"Registered plugin: {plugin_name}")
 
-    def get_plugin(self, name: str) -> Type[NetworkPlugin]:
+    def get_plugin(self, name: str) -> Type[DataHubPlugin]:
         """
         Get a plugin by name.
 
@@ -244,7 +244,7 @@ class PluginRegistry:
         """
         return list(self._plugins.keys())
 
-    def create_instance(self, name: str, **config) -> NetworkPlugin:
+    def create_instance(self, name: str, **config) -> DataHubPlugin:
         """
         Create an instance of a plugin.
 

--- a/src/fluxnet_shuttle/main.py
+++ b/src/fluxnet_shuttle/main.py
@@ -15,15 +15,15 @@ This module provides the command-line interface for the FLUXNET Shuttle Library,
 allowing users to discover and download FLUXNET data from the command line.
 
 The CLI supports operations for listing available datasets, downloading data,
-checking supported data sources, and testing network connectivity.
+checking supported data sources.
 
 Commands
 --------
 
-* ``listall`` - List all available datasets from supported networks
-* ``download`` - Download datasets from specified networks
-* ``sources`` - Display information about supported data sources
-* ``test`` - Test connectivity to data sources
+* ``listall`` - List all available datasets from supported data hubs
+* ``download`` - Download datasets from specified data hubs
+* ``listdatahubs`` - Display information about supported data hubs
+* ``test`` - Test connectivity to data hubs
 
 Examples
 --------
@@ -198,16 +198,16 @@ def cmd_download(args) -> List[str]:
     return downloaded_files
 
 
-def cmd_sources(args: Any) -> None:
-    """Execute the sources command - show available data source plugins."""
+def cmd_listdatahubs(args: Any) -> None:
+    """Execute the listdatahubs command - show available data hub plugins."""
     log = logging.getLogger(__name__)
     from .core.registry import registry
 
-    log.info("Available FLUXNET network plugins:")
+    log.info("Available FLUXNET data hub plugins:")
 
     plugin_names = registry.list_plugins()
     if not plugin_names:
-        log.warning("No network plugins found")
+        log.warning("No data hub plugins found")
         return
 
     for plugin_name in sorted(plugin_names):
@@ -224,7 +224,7 @@ def main() -> None:
     # Main parser
     parser = argparse.ArgumentParser(
         prog="fluxnet-shuttle",
-        description="FLUXNET Shuttle - Download and manage FLUXNET data from multiple networks",
+        description="FLUXNET Shuttle - Download and manage FLUXNET data from multiple data hubs",
         epilog="For more information, visit: https://github.com/AMF-FLX/fluxnet-shuttle-lib",
     )
 
@@ -251,7 +251,7 @@ def main() -> None:
     parser_listall = subparsers.add_parser(
         "listall",
         help="List all available FLUXNET datasets",
-        description="Fetch and save a snapshot of all available FLUXNET datasets from configured networks",
+        description="Fetch and save a snapshot of all available FLUXNET datasets from configured data hubs",
     )
     parser_listall.add_argument(
         "-o",
@@ -301,11 +301,11 @@ def main() -> None:
         dest="quiet",
     )
 
-    # sources command
+    # listdatahubs command
     subparsers.add_parser(
-        "sources",
-        help="List available data source plugins",
-        description="Display information about available FLUXNET network plugins",
+        "listdatahubs",
+        help="List available data hub plugins",
+        description="Display information about available FLUXNET data hub plugins",
     )
 
     args = parser.parse_args()
@@ -325,8 +325,8 @@ def main() -> None:
             cmd_listall(args)
         elif args.command == "download":
             cmd_download(args)
-        elif args.command == "sources":
-            cmd_sources(args)
+        elif args.command == "listdatahubs":
+            cmd_listdatahubs(args)
         else:
             log.error(f"Unknown command: {args.command}")
             sys.exit(1)

--- a/src/fluxnet_shuttle/models.py
+++ b/src/fluxnet_shuttle/models.py
@@ -24,7 +24,7 @@ Classes:
 
 The models are designed to work with the FLUXNET data format and provide
 validation for:
-    - Network and publisher information
+    - Data hub and publisher information
     - Site identifiers and temporal coverage
     - Dataset versions and file metadata
     - Download URLs with validation
@@ -34,7 +34,7 @@ Example:
     >>> from fluxnet_shuttle.models.schema import FluxnetDatasetMetadata
     >>> site_info = BadmSiteGeneralInfo(
     ...     site_id="US-Ha1",
-    ...     network="AmeriFlux",
+    ...     data_hub="AmeriFlux",
     ...     location_lat=42.5378,
     ...     location_long=-72.1715,
     ...     igbp="DBF"
@@ -73,7 +73,7 @@ class BadmSiteGeneralInfo(BaseModel):
 
     Attributes:
         site_id (str): Site identifier by country using first two chars or clusters
-        network (str): Network name (e.g., AmeriFlux, ICOS)
+        data_hub (str): Data hub name (e.g., AmeriFlux, ICOS)
         location_lat (float): Site latitude in decimal degrees
         location_long (float): Site longitude in decimal degrees
         igbp (str): IGBP land cover type classification
@@ -88,9 +88,10 @@ class BadmSiteGeneralInfo(BaseModel):
         max_length=20,
     )
 
-    network: str = Field(
+    # data_hub is not part of the BADM Standard but including in the BADM SGI model"
+    data_hub: str = Field(
         ...,
-        description="Network name (e.g., AmeriFlux, ICOS, NEON)",
+        description="Data hub name (e.g., AmeriFlux, ICOS, NEON)",
         min_length=1,
         max_length=50,
     )
@@ -172,10 +173,10 @@ class PluginErrorDetail(BaseModel):
     Pydantic model for individual plugin error details.
 
     This model represents an error that occurred during plugin execution,
-    including context about which network/plugin encountered the error.
+    including context about which data hub/plugin encountered the error.
 
     Attributes:
-        network (str): Network/plugin name where the error occurred
+        data_hub (str): Data hub/plugin name where the error occurred
         operation (str): Operation being performed when the error occurred
         error (str): Error message or description
         timestamp (str): ISO format timestamp when the error occurred
@@ -183,7 +184,7 @@ class PluginErrorDetail(BaseModel):
 
     model_config = ConfigDict(str_strip_whitespace=True, validate_assignment=True, extra="forbid")
 
-    network: str = Field(..., description="Network/plugin name where the error occurred", min_length=1)
+    data_hub: str = Field(..., description="Data hub/plugin name where the error occurred", min_length=1)
 
     operation: str = Field(..., description="Operation being performed when the error occurred", min_length=1)
 

--- a/src/fluxnet_shuttle/plugins/__init__.py
+++ b/src/fluxnet_shuttle/plugins/__init__.py
@@ -1,5 +1,5 @@
 """
-Network-specific plugins for FLUXNET Shuttle Library
+Data hub-specific plugins for FLUXNET Shuttle Library
 
 :module:: fluxnet_shuttle.plugins
 :moduleauthor: Valerie Hendrix <vchendrix@lbl.gov>
@@ -8,7 +8,7 @@ Network-specific plugins for FLUXNET Shuttle Library
 
 .. currentmodule:: fluxnet_shuttle.plugins
 
-This module contains network-specific plugins for accessing different
+This module contains data hub-specific plugins for accessing different
 FLUXNET data sources.
 """
 

--- a/src/fluxnet_shuttle/plugins/ameriflux.py
+++ b/src/fluxnet_shuttle/plugins/ameriflux.py
@@ -1,8 +1,8 @@
 """
-AmeriFlux Network Plugin
-========================
+AmeriFlux Data Hub Plugin
+=========================
 
-AmeriFlux network implementation for the FLUXNET Shuttle plugin system.
+AmeriFlux data hub implementation for the FLUXNET Shuttle plugin system.
 """
 
 import asyncio
@@ -13,7 +13,7 @@ from pydantic import HttpUrl
 
 from fluxnet_shuttle.core.exceptions import PluginError
 
-from ..core.base import NetworkPlugin
+from ..core.base import DataHubPlugin
 from ..core.decorators import async_to_sync_generator
 from ..models import BadmSiteGeneralInfo, DataFluxnetProduct, FluxnetDatasetMetadata
 
@@ -27,8 +27,8 @@ AMERIFLUX_DOWNLOAD_PATH = "amf_shuttle_data_files_and_manifest"
 AMERIFLUX_HEADERS = {"Content-Type": "application/json"}
 
 
-class AmeriFluxPlugin(NetworkPlugin):
-    """AmeriFlux network plugin implementation."""
+class AmeriFluxPlugin(DataHubPlugin):
+    """AmeriFlux data hub plugin implementation."""
 
     @property
     def name(self) -> str:
@@ -160,7 +160,7 @@ class AmeriFluxPlugin(NetworkPlugin):
 
         return BadmSiteGeneralInfo(
             site_id=site_id,
-            network="AmeriFlux",
+            data_hub="AmeriFlux",
             location_lat=location_lat,
             location_long=location_long,
             igbp=igbp,

--- a/src/fluxnet_shuttle/plugins/config.yaml
+++ b/src/fluxnet_shuttle/plugins/config.yaml
@@ -4,8 +4,8 @@
 # Global settings
 parallel_requests: 2
 
-# Network-specific configurations
-networks:
+# Data hub-specific configurations
+data_hubs:
   ameriflux:
     enabled: true
 

--- a/src/fluxnet_shuttle/plugins/icos.py
+++ b/src/fluxnet_shuttle/plugins/icos.py
@@ -1,15 +1,15 @@
 """
-ICOS Network Plugin
-===================
+ICOS Data Hub Plugin
+====================
 
-ICOS Carbon Portal network implementation for the FLUXNET Shuttle plugin system.
+ICOS Carbon Portal data hub implementation for the FLUXNET Shuttle plugin system.
 """
 
 import asyncio
 import logging
 from typing import Any, AsyncGenerator, Dict, Generator
 
-from ..core.base import NetworkPlugin
+from ..core.base import DataHubPlugin
 from ..core.decorators import async_to_sync_generator
 from ..models import BadmSiteGeneralInfo, DataFluxnetProduct, FluxnetDatasetMetadata
 
@@ -51,8 +51,8 @@ order by desc(?fileName)
 """
 
 
-class ICOSPlugin(NetworkPlugin):
-    """ICOS Carbon Portal network plugin implementation."""
+class ICOSPlugin(DataHubPlugin):
+    """ICOS Carbon Portal data hub plugin implementation."""
 
     @property
     def name(self) -> str:
@@ -162,7 +162,7 @@ class ICOSPlugin(NetworkPlugin):
 
                 site_info = BadmSiteGeneralInfo(
                     site_id=station_id,
-                    network="ICOS",
+                    data_hub="ICOS",
                     location_lat=location_lat,
                     location_long=location_long,
                     igbp=igbp,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 @pytest.fixture
 def temp_csv_file():
     """Create a temporary CSV file for testing."""
-    content = "site_id,network,filename,download_link\n"
+    content = "site_id,data_hub,filename,download_link\n"
     content += "US-TEST,AmeriFlux,test_ameriflux.zip,http://example.com/ameriflux.zip\n"
     content += "IT-TEST,ICOS,test_icos.zip,http://example.com/icos.zip\n"
 

--- a/tests/integration/test_core_shuttle_integration.py
+++ b/tests/integration/test_core_shuttle_integration.py
@@ -25,14 +25,14 @@ class TestFluxnetShuttle:
 
     def test_get_all_sites_no_plugins(self):
         """Test getting all sites when no plugins are specified."""
-        shuttle = FluxnetShuttle(networks=[])
+        shuttle = FluxnetShuttle(data_hubs=[])
         sites = list(shuttle.get_all_sites())
         assert sites == []
 
     def test_get_all_sites_with_plugins(self):
         """Test getting all sites with specified plugins."""
         # This test assumes that the 'ameriflux' and 'icos' plugins are available.
-        shuttle = FluxnetShuttle(networks=["ameriflux", "icos"])
+        shuttle = FluxnetShuttle(data_hubs=["ameriflux", "icos"])
         sites = list(shuttle.get_all_sites())
         assert isinstance(sites, list)
         # We can't guarantee there are sites without network access,
@@ -41,7 +41,7 @@ class TestFluxnetShuttle:
     def test_get_all_sites_with_plugins_only_icos(self):
         """Test getting all sites with specified plugins."""
         # This test assumes that the 'icos' plugin is available.
-        shuttle = FluxnetShuttle(networks=["icos"])
+        shuttle = FluxnetShuttle(data_hubs=["icos"])
         sites = list(shuttle.get_all_sites())
         assert isinstance(sites, list)
         # We can't guarantee there are sites without network access,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 
 import pytest
 
-from fluxnet_shuttle.main import cmd_download, cmd_listall, cmd_sources, main, setup_logging
+from fluxnet_shuttle.main import cmd_download, cmd_listall, cmd_listdatahubs, main, setup_logging
 
 
 class TestCLIIntegration:
@@ -215,7 +215,7 @@ class TestCLIFunctions:
     @patch("fluxnet_shuttle.main.listall")
     def test_cmd_listall_basic(self, mock_listall):
         """Test cmd_listall function."""
-        mock_listall.return_value = [{"site_id": "US-Ha1", "network": "AmeriFlux", "data_url": "http://example.com"}]
+        mock_listall.return_value = [{"site_id": "US-Ha1", "data_hub": "AmeriFlux", "data_url": "http://example.com"}]
 
         # Create mock args
         args = argparse.Namespace(output="test_output.csv", logfile="test.log", no_logfile=False, verbose=False)
@@ -243,7 +243,7 @@ class TestCLIFunctions:
 
         # Create a temporary CSV file
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp:
-            tmp.write("site_id,network\nUS-Ha1,AmeriFlux\nUS-MMS,AmeriFlux\n")
+            tmp.write("site_id,data_hub\nUS-Ha1,AmeriFlux\nUS-MMS,AmeriFlux\n")
             csv_file = tmp.name
 
         try:
@@ -275,7 +275,7 @@ class TestCLIFunctions:
 
         # Create a temporary CSV file
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp:
-            tmp.write("site_id,network\nUS-Ha1,AmeriFlux\nUS-MMS,AmeriFlux\n")
+            tmp.write("site_id,data_hub\nUS-Ha1,AmeriFlux\nUS-MMS,AmeriFlux\n")
             csv_file = tmp.name
 
         try:
@@ -338,7 +338,7 @@ class TestCLIFunctions:
         """Test cmd_download with CSV file missing site_id column."""
         # Create a temporary CSV file without site_id column
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp:
-            tmp.write("name,network\nTest Site,AmeriFlux\n")
+            tmp.write("name,data_hub\nTest Site,AmeriFlux\n")
             csv_file = tmp.name
 
         try:
@@ -376,12 +376,12 @@ class TestCLIFunctions:
             cmd_download(args)
         assert exc_info.value.code == 1
 
-    def test_cmd_sources(self):
-        """Test cmd_sources function."""
+    def test_cmd_listdatahubs(self):
+        """Test cmd_listdatahubs function."""
         args = argparse.Namespace(logfile="test.log", no_logfile=False, verbose=False)
 
         # Should not raise any exception
-        cmd_sources(args)
+        cmd_listdatahubs(args)
 
     def test_main_with_version(self):
         """Test main function with --version argument."""
@@ -410,10 +410,10 @@ class TestCLIFunctions:
             main()
             mock_cmd.assert_called_once()
 
-    @patch("fluxnet_shuttle.main.cmd_sources")
-    def test_main_with_sources_command(self, mock_cmd):
-        """Test main function with sources command."""
-        test_args = ["fluxnet-shuttle", "--no-logfile", "sources"]
+    @patch("fluxnet_shuttle.main.cmd_listdatahubs")
+    def test_main_with_listdatahubs_command(self, mock_cmd):
+        """Test main function with listdatahubs command."""
+        test_args = ["fluxnet-shuttle", "--no-logfile", "listdatahubs"]
 
         with patch("sys.argv", test_args):
             main()
@@ -436,26 +436,26 @@ class TestCLIFunctions:
                     main()
                 assert exc_info.value.code == 1
 
-    @patch("fluxnet_shuttle.main.cmd_sources")
+    @patch("fluxnet_shuttle.main.cmd_listdatahubs")
     def test_main_fluxnet_shuttle_error(self, mock_cmd):
         """Test main function error handling for FLUXNETShuttleError."""
         from fluxnet_shuttle import FLUXNETShuttleError
 
         mock_cmd.side_effect = FLUXNETShuttleError("Test error")
 
-        test_args = ["fluxnet-shuttle", "--no-logfile", "sources"]
+        test_args = ["fluxnet-shuttle", "--no-logfile", "listdatahubs"]
 
         with patch("sys.argv", test_args):
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 1
 
-    @patch("fluxnet_shuttle.main.cmd_sources")
+    @patch("fluxnet_shuttle.main.cmd_listdatahubs")
     def test_main_unexpected_error(self, mock_cmd):
         """Test main function error handling for unexpected exceptions."""
         mock_cmd.side_effect = RuntimeError("Unexpected error")
 
-        test_args = ["fluxnet-shuttle", "--no-logfile", "sources"]
+        test_args = ["fluxnet-shuttle", "--no-logfile", "listdatahubs"]
 
         with patch("sys.argv", test_args):
             with pytest.raises(SystemExit) as exc_info:
@@ -466,7 +466,7 @@ class TestCLIFunctions:
         """Test cmd_download with CSV file that causes read error."""
         # Create a temporary file that's not readable (permission error)
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp:
-            tmp.write("site_id,network\nUS-Ha1,AmeriFlux\n")
+            tmp.write("site_id,data_hub\nUS-Ha1,AmeriFlux\n")
             csv_file = tmp.name
 
         try:
@@ -540,7 +540,7 @@ class TestCLIFunctions:
     def test_cmd_download_input_confirmation_no(self):
         """Test cmd_download with user declining confirmation."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp:
-            tmp.write("site_id,network\nUS-Ha1,AmeriFlux\n")
+            tmp.write("site_id,data_hub\nUS-Ha1,AmeriFlux\n")
             csv_file = tmp.name
 
         try:
@@ -577,16 +577,16 @@ class TestCLIFunctions:
                 assert tmpdir in result
                 mock_listall.assert_called_once()
 
-    def test_cmd_sources_no_plugins(self):
-        """Test cmd_sources when no plugins are registered."""
-        from fluxnet_shuttle.main import cmd_sources
+    def test_cmd_listdatahubs_no_plugins(self):
+        """Test cmd_listdatahubs when no plugins are registered."""
+        from fluxnet_shuttle.main import cmd_listdatahubs
 
         args = argparse.Namespace(logfile="test.log", no_logfile=False, verbose=False)
 
         # Mock registry to return empty list
         with patch("fluxnet_shuttle.core.registry.registry.list_plugins", return_value=[]):
             # Should not raise exception, just log warning
-            cmd_sources(args)
+            cmd_listdatahubs(args)
 
     def test_version_import_error(self):
         """Test version fallback when package is not found."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,7 @@ def sample_site_info():
     """Fixture providing sample site general information."""
     return BadmSiteGeneralInfo(
         site_id="US-ARc",
-        network="AmeriFlux",
+        data_hub="AmeriFlux",
         location_lat=68.1396,
         location_long=-149.5892,
         igbp="WET",
@@ -53,7 +53,7 @@ def sample_metadata(sample_site_info, sample_product_data):
 def test_badm_site_general_info_valid_creation(sample_site_info):
     """Test creating a valid BadmSiteGeneralInfo instance."""
     assert sample_site_info.site_id == "US-ARc"
-    assert sample_site_info.network == "AmeriFlux"
+    assert sample_site_info.data_hub == "AmeriFlux"
     assert sample_site_info.location_lat == 68.1396
     assert sample_site_info.location_long == -149.5892
     assert sample_site_info.igbp == "WET"
@@ -66,7 +66,7 @@ def test_badm_site_general_info_site_id_validation():
     for site_id in valid_site_ids:
         site_info = BadmSiteGeneralInfo(
             site_id=site_id,
-            network="AmeriFlux",
+            data_hub="AmeriFlux",
             location_lat=45.0,
             location_long=2.0,
             igbp="ENF",
@@ -79,7 +79,7 @@ def test_badm_site_general_info_site_id_validation():
         with pytest.raises(ValidationError):
             BadmSiteGeneralInfo(
                 site_id=site_id,
-                network="AmeriFlux",
+                data_hub="AmeriFlux",
                 location_lat=45.0,
                 location_long=2.0,
                 igbp="ENF",
@@ -93,7 +93,7 @@ def test_badm_site_general_info_latitude_validation():
     for lat in valid_lats:
         site_info = BadmSiteGeneralInfo(
             site_id="US-ARc",
-            network="AmeriFlux",
+            data_hub="AmeriFlux",
             location_lat=lat,
             location_long=0.0,
             igbp="WET",
@@ -106,7 +106,7 @@ def test_badm_site_general_info_latitude_validation():
         with pytest.raises(ValidationError):
             BadmSiteGeneralInfo(
                 site_id="US-ARc",
-                network="AmeriFlux",
+                data_hub="AmeriFlux",
                 location_lat=lat,
                 location_long=0.0,
                 igbp="WET",
@@ -120,7 +120,7 @@ def test_badm_site_general_info_longitude_validation():
     for lon in valid_lons:
         site_info = BadmSiteGeneralInfo(
             site_id="US-ARc",
-            network="AmeriFlux",
+            data_hub="AmeriFlux",
             location_lat=0.0,
             location_long=lon,
             igbp="WET",
@@ -133,7 +133,7 @@ def test_badm_site_general_info_longitude_validation():
         with pytest.raises(ValidationError):
             BadmSiteGeneralInfo(
                 site_id="US-ARc",
-                network="AmeriFlux",
+                data_hub="AmeriFlux",
                 location_lat=0.0,
                 location_long=lon,
                 igbp="WET",
@@ -149,7 +149,7 @@ def test_badm_site_general_info_required_fields():
         BadmSiteGeneralInfo(site_id="US-ARc")
 
     with pytest.raises(ValidationError):
-        BadmSiteGeneralInfo(site_id="US-ARc", network="AmeriFlux")
+        BadmSiteGeneralInfo(site_id="US-ARc", data_hub="AmeriFlux")
 
 
 # Tests for DataFluxnetProduct
@@ -236,7 +236,7 @@ def test_fluxnet_dataset_metadata_nested_validation():
         FluxnetDatasetMetadata(
             site_info=BadmSiteGeneralInfo(
                 site_id="INVALID",  # Bad format
-                network="AmeriFlux",
+                data_hub="AmeriFlux",
                 location_lat=68.1396,
                 location_long=-149.5892,
                 igbp="WET",
@@ -253,7 +253,7 @@ def test_fluxnet_dataset_metadata_nested_validation():
         FluxnetDatasetMetadata(
             site_info=BadmSiteGeneralInfo(
                 site_id="US-ARc",
-                network="AmeriFlux",
+                data_hub="AmeriFlux",
                 location_lat=68.1396,
                 location_long=-149.5892,
                 igbp="WET",
@@ -271,7 +271,7 @@ def test_site_info_json_serialization(sample_site_info):
     """Test JSON serialization of BadmSiteGeneralInfo."""
     json_data = sample_site_info.model_dump()
     assert json_data["site_id"] == "US-ARc"
-    assert json_data["network"] == "AmeriFlux"
+    assert json_data["data_hub"] == "AmeriFlux"
     assert json_data["location_lat"] == 68.1396
     assert json_data["location_long"] == -149.5892
     assert json_data["igbp"] == "WET"
@@ -308,12 +308,12 @@ def test_plugin_error_detail_valid_creation():
     """Test creating a valid PluginErrorDetail instance."""
     timestamp = datetime.now().isoformat()
     error_detail = PluginErrorDetail(
-        network="ameriflux",
+        data_hub="ameriflux",
         operation="get_sites",
         error="Connection timeout",
         timestamp=timestamp,
     )
-    assert error_detail.network == "ameriflux"
+    assert error_detail.data_hub == "ameriflux"
     assert error_detail.operation == "get_sites"
     assert error_detail.error == "Connection timeout"
     assert error_detail.timestamp == timestamp
@@ -331,7 +331,7 @@ def test_plugin_error_detail_timestamp_validation():
     ]
     for timestamp in valid_timestamps:
         error_detail = PluginErrorDetail(
-            network="ameriflux",
+            data_hub="ameriflux",
             operation="get_sites",
             error="Test error",
             timestamp=timestamp,
@@ -348,7 +348,7 @@ def test_plugin_error_detail_timestamp_validation():
     for timestamp in invalid_timestamps:
         with pytest.raises(ValidationError) as exc_info:
             PluginErrorDetail(
-                network="ameriflux",
+                data_hub="ameriflux",
                 operation="get_sites",
                 error="Test error",
                 timestamp=timestamp,
@@ -358,7 +358,7 @@ def test_plugin_error_detail_timestamp_validation():
     # Empty string should fail with min_length validation
     with pytest.raises(ValidationError):
         PluginErrorDetail(
-            network="ameriflux",
+            data_hub="ameriflux",
             operation="get_sites",
             error="Test error",
             timestamp="",
@@ -371,10 +371,10 @@ def test_plugin_error_detail_required_fields():
         PluginErrorDetail()
 
     with pytest.raises(ValidationError):
-        PluginErrorDetail(network="ameriflux")
+        PluginErrorDetail(data_hub="ameriflux")
 
     with pytest.raises(ValidationError):
-        PluginErrorDetail(network="ameriflux", operation="get_sites")
+        PluginErrorDetail(data_hub="ameriflux", operation="get_sites")
 
 
 def test_plugin_error_detail_min_length_validation():
@@ -383,13 +383,13 @@ def test_plugin_error_detail_min_length_validation():
 
     # Empty strings should fail
     with pytest.raises(ValidationError):
-        PluginErrorDetail(network="", operation="get_sites", error="Test error", timestamp=timestamp)
+        PluginErrorDetail(data_hub="", operation="get_sites", error="Test error", timestamp=timestamp)
 
     with pytest.raises(ValidationError):
-        PluginErrorDetail(network="ameriflux", operation="", error="Test error", timestamp=timestamp)
+        PluginErrorDetail(data_hub="ameriflux", operation="", error="Test error", timestamp=timestamp)
 
     with pytest.raises(ValidationError):
-        PluginErrorDetail(network="ameriflux", operation="get_sites", error="", timestamp=timestamp)
+        PluginErrorDetail(data_hub="ameriflux", operation="get_sites", error="", timestamp=timestamp)
 
 
 # Tests for ErrorSummary
@@ -397,7 +397,7 @@ def test_error_summary_valid_creation():
     """Test creating a valid ErrorSummary instance."""
     timestamp = datetime.now().isoformat()
     error_detail = PluginErrorDetail(
-        network="ameriflux",
+        data_hub="ameriflux",
         operation="get_sites",
         error="Connection timeout",
         timestamp=timestamp,
@@ -430,13 +430,13 @@ def test_error_summary_multiple_errors():
     timestamp = datetime.now().isoformat()
     errors = [
         PluginErrorDetail(
-            network="ameriflux",
+            data_hub="ameriflux",
             operation="get_sites",
             error="Connection timeout",
             timestamp=timestamp,
         ),
         PluginErrorDetail(
-            network="icos",
+            data_hub="icos",
             operation="get_sites",
             error="API rate limit exceeded",
             timestamp=timestamp,
@@ -456,7 +456,7 @@ def test_error_summary_non_negative_validation():
     """Test that total_errors and total_results must be non-negative."""
     timestamp = datetime.now().isoformat()
     error_detail = PluginErrorDetail(
-        network="ameriflux",
+        data_hub="ameriflux",
         operation="get_sites",
         error="Test error",
         timestamp=timestamp,
@@ -475,7 +475,7 @@ def test_error_summary_json_serialization():
     """Test JSON serialization of ErrorSummary."""
     timestamp = datetime.now().isoformat()
     error_detail = PluginErrorDetail(
-        network="ameriflux",
+        data_hub="ameriflux",
         operation="get_sites",
         error="Connection timeout",
         timestamp=timestamp,
@@ -491,7 +491,7 @@ def test_error_summary_json_serialization():
     assert json_data["total_errors"] == 1
     assert json_data["total_results"] == 10
     assert len(json_data["errors"]) == 1
-    assert json_data["errors"][0]["network"] == "ameriflux"
+    assert json_data["errors"][0]["data_hub"] == "ameriflux"
 
     # Test round-trip
     reconstructed = ErrorSummary(**json_data)

--- a/tests/test_plugin_ameriflux.py
+++ b/tests/test_plugin_ameriflux.py
@@ -60,7 +60,7 @@ class TestAmeriFluxPlugin:
             str(sites[0].product_data.download_link)
             == "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/AMF_AR-Bal_FLUXNET_FULLSET_2012-2013_3-7.zip"
         )
-        assert sites[0].site_info.network == "AmeriFlux"
+        assert sites[0].site_info.data_hub == "AmeriFlux"
         assert sites[0].site_info.location_lat == -37.7596  # Real value from metadata
         assert sites[0].site_info.location_long == -58.3024  # Real value from metadata
         assert sites[0].site_info.igbp == "CRO"  # Real value from metadata
@@ -72,7 +72,7 @@ class TestAmeriFluxPlugin:
             str(sites[1].product_data.download_link)
             == "https://ftp.fluxdata.org/.ameriflux_downloads/FLUXNET/AMF_AR-CCa_FLUXNET_FULLSET_2012-2020_3-7.zip"
         )
-        assert sites[1].site_info.network == "AmeriFlux"
+        assert sites[1].site_info.data_hub == "AmeriFlux"
         assert sites[1].site_info.location_lat == -31.4821  # Real value from metadata
         assert sites[1].site_info.location_long == -63.6458  # Real value from metadata
         assert sites[1].site_info.igbp == "GRA"  # Real value from metadata
@@ -105,7 +105,7 @@ class TestAmeriFluxPlugin:
         assert sites[0].product_data.first_year == 2005  # From publish_years
         assert sites[0].product_data.last_year == 2007  # From publish_years
         assert str(sites[0].product_data.download_link) == "http://example.com/US-XYZ_invalidformat.zip"
-        assert sites[0].site_info.network == "AmeriFlux"
+        assert sites[0].site_info.data_hub == "AmeriFlux"
         assert sites[0].site_info.location_lat == 45.0  # From metadata
         assert sites[0].site_info.location_long == -90.0  # From metadata
         assert sites[0].site_info.igbp == "DBF"  # From metadata
@@ -151,7 +151,7 @@ class TestAmeriFluxPlugin:
         assert (
             str(sites[0].product_data.download_link) == "http://example.com/US-ABC__FLUXNET_FULLSET_2005-2012_3-7.zip"
         )
-        assert sites[0].site_info.network == "AmeriFlux"
+        assert sites[0].site_info.data_hub == "AmeriFlux"
         assert sites[0].site_info.location_lat == 40.0  # From metadata
         assert sites[0].site_info.location_long == -100.0  # From metadata
         assert sites[0].site_info.igbp == "GRA"  # From metadata
@@ -197,7 +197,7 @@ class TestAmeriFluxPlugin:
         assert len(sites) == 0  # No valid sites should be returned due to malformed data
 
     @pytest.mark.asyncio
-    @patch("fluxnet_shuttle.plugins.ameriflux.NetworkPlugin._session_request")
+    @patch("fluxnet_shuttle.plugins.ameriflux.DataHubPlugin._session_request")
     async def test__get_site_metadata(self, mock_request):
         """Test _get_site_metadata handles _session_request correctly."""
         mock_response = AsyncMock()
@@ -227,7 +227,7 @@ class TestAmeriFluxPlugin:
 
     @pytest.mark.asyncio
     @patch(
-        "fluxnet_shuttle.plugins.ameriflux.NetworkPlugin._session_request",
+        "fluxnet_shuttle.plugins.ameriflux.DataHubPlugin._session_request",
         side_effect=PluginError("ameriflux", "Test error"),
     )
     async def test__get_site_metadata_failure(self, mock_request):
@@ -240,7 +240,7 @@ class TestAmeriFluxPlugin:
 
     @pytest.mark.asyncio
     @patch(
-        "fluxnet_shuttle.plugins.ameriflux.NetworkPlugin._session_request",
+        "fluxnet_shuttle.plugins.ameriflux.DataHubPlugin._session_request",
         side_effect=PluginError("ameriflux", "Test error"),
     )
     async def test__get_download_links_with_failure(self, mock_request):
@@ -252,7 +252,7 @@ class TestAmeriFluxPlugin:
         assert mock_request.call_count == 1  # Ensure the request was attempted
 
     @pytest.mark.asyncio
-    @patch("fluxnet_shuttle.plugins.ameriflux.NetworkPlugin._session_request")
+    @patch("fluxnet_shuttle.plugins.ameriflux.DataHubPlugin._session_request")
     async def test__get_download_links_success(self, mock_request):
         """Test _get_download_links returns expected data on success."""
         mock_response = MagicMock()
@@ -307,7 +307,7 @@ class TestAmeriFluxPlugin:
             str(results[0].product_data.download_link)
             == "http://example.com/US-TEST__FLUXNET_FULLSET_2005-2012_3-7.zip"
         )
-        assert results[0].site_info.network == "AmeriFlux"
+        assert results[0].site_info.data_hub == "AmeriFlux"
 
     def test_parse_response_filters_sites_without_publish_years(self):
         """Test _parse_response filters out sites with no publish years."""

--- a/tests/test_plugin_icos.py
+++ b/tests/test_plugin_icos.py
@@ -28,7 +28,7 @@ class TestICOSPlugin:
         assert plugin.config["api_url"] == "https://test.icos-cp.eu"
 
     @pytest.mark.asyncio
-    @patch("fluxnet_shuttle.plugins.icos.NetworkPlugin._session_request")
+    @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
     async def test_async_get_sites(self, mock_request):
         """Test async get_sites method."""
         mock_response = AsyncMock()
@@ -58,7 +58,7 @@ class TestICOSPlugin:
         assert len(sites) == 1
         assert all(isinstance(site, FluxnetDatasetMetadata) for site in sites)
         assert sites[0].site_info.site_id == "US-ABC"
-        assert sites[0].site_info.network == "ICOS"
+        assert sites[0].site_info.data_hub == "ICOS"
         assert sites[0].site_info.location_lat == 12.34
         assert sites[0].site_info.location_long == 56.78
         assert sites[0].site_info.igbp == "ENF"
@@ -70,7 +70,7 @@ class TestICOSPlugin:
         )
 
     @pytest.mark.asyncio
-    @patch("fluxnet_shuttle.plugins.icos.NetworkPlugin._session_request")
+    @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
     async def test_async_get_sites_with_time_errors(self, mock_request):
         """Test async get_sites method."""
         mock_response = AsyncMock()
@@ -99,7 +99,7 @@ class TestICOSPlugin:
         assert len(sites) == 1
         assert all(isinstance(site, FluxnetDatasetMetadata) for site in sites)
         assert sites[0].site_info.site_id == "US-ABC"
-        assert sites[0].site_info.network == "ICOS"
+        assert sites[0].site_info.data_hub == "ICOS"
         assert sites[0].site_info.location_lat == 12.34
         assert sites[0].site_info.location_long == 56.78
         assert sites[0].site_info.igbp == "UNK"
@@ -113,7 +113,7 @@ class TestICOSPlugin:
         assert mock_request.call_count == 1
 
     @pytest.mark.asyncio
-    @patch("fluxnet_shuttle.plugins.icos.NetworkPlugin._session_request")
+    @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
     async def test_async_get_sites_with_errors(self, mock_request, caplog):
         """Test async get_sites method with invalid latitude."""
         mock_response = AsyncMock()
@@ -174,7 +174,7 @@ class TestICOSPlugin:
         assert plugin._map_ecosystem_to_igbp("some_random_text") == "UNK"
 
     @pytest.mark.asyncio
-    @patch("fluxnet_shuttle.plugins.icos.NetworkPlugin._session_request")
+    @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
     async def test_async_get_sites_with_invalid_longitude(self, mock_request, caplog):
         """Test async get_sites method with invalid longitude."""
         mock_response = AsyncMock()
@@ -213,7 +213,7 @@ class TestICOSPlugin:
         assert mock_request.call_count == 1
 
     @pytest.mark.asyncio
-    @patch("fluxnet_shuttle.plugins.icos.NetworkPlugin._session_request")
+    @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")
     async def test_async_get_sites_with_general_exception(self, mock_request, caplog):
         """Test async get_sites handles general exceptions during parsing."""
         mock_response = AsyncMock()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,12 +4,12 @@ Test Registry
 
 import pytest
 
-from fluxnet_shuttle.core.base import NetworkPlugin
+from fluxnet_shuttle.core.base import DataHubPlugin
 from fluxnet_shuttle.core.decorators import async_to_sync_generator
 from fluxnet_shuttle.core.registry import ErrorCollectingIterator, PluginRegistry
 
 
-class DummyPlugin(NetworkPlugin):
+class DummyPlugin(DataHubPlugin):
     @property
     def name(self):
         return "dummy"
@@ -53,7 +53,7 @@ class TestPluginRegistry:
         class InvalidPlugin:
             pass
 
-        with pytest.raises(TypeError, match="Plugin class must inherit from NetworkPlugin"):
+        with pytest.raises(TypeError, match="Plugin class must inherit from DataHubPlugin"):
             registry.register(InvalidPlugin)
 
     def test_get_nonexistent_plugin(self):

--- a/tests/test_shuttle.py
+++ b/tests/test_shuttle.py
@@ -243,7 +243,7 @@ class TestDownload:
         # Create a mock snapshot file with multiple sites
         snapshot_file = tmp_path / "snapshot.csv"
         snapshot_file.write_text(
-            "network,site_id,first_year,last_year,download_link\n"
+            "data_hub,site_id,first_year,last_year,download_link\n"
             "AmeriFlux,US-Ha1,2000,2020,https://example.com/US-Ha1.zip\n"
             "AmeriFlux,US-MMS,2005,2021,https://example.com/US-MMS.zip\n"
         )
@@ -274,7 +274,7 @@ class TestDownload:
     @patch("os.path.exists")
     @patch(
         "builtins.open",
-        mock_open(read_data="site_id,network,download_link\n" "US-TEST,AmeriFlux,http://example.com/test.zip\n"),
+        mock_open(read_data="site_id,data_hub,download_link\n" "US-TEST,AmeriFlux,http://example.com/test.zip\n"),
     )
     def test_download_ameriflux_site_success(self, mock_exists, mock_download):
         """Test successful download of AmeriFlux site."""
@@ -286,7 +286,7 @@ class TestDownload:
         assert result == ["test.zip"]
         mock_download.assert_called_once_with(
             site_id="US-TEST",
-            network="AmeriFlux",
+            data_hub="AmeriFlux",
             filename="test.zip",
             download_link="http://example.com/test.zip",
             output_dir=".",
@@ -296,7 +296,7 @@ class TestDownload:
     @patch("os.path.exists")
     @patch(
         "builtins.open",
-        mock_open(read_data="site_id,network,download_link\n" "FI-HYY,ICOS,http://example.com/test.zip\n"),
+        mock_open(read_data="site_id,data_hub,download_link\n" "FI-HYY,ICOS,http://example.com/test.zip\n"),
     )
     def test_download_icos_site_success(self, mock_exists, mock_download):
         """Test successful download of ICOS site."""
@@ -308,7 +308,7 @@ class TestDownload:
         assert result == ["test.zip"]
         mock_download.assert_called_once_with(
             site_id="FI-HYY",
-            network="ICOS",
+            data_hub="ICOS",
             filename="test.zip",
             download_link="http://example.com/test.zip",
             output_dir=".",
@@ -319,7 +319,7 @@ class TestDownload:
     @patch(
         "builtins.open",
         mock_open(
-            read_data="site_id,network,download_link\n"
+            read_data="site_id,data_hub,download_link\n"
             "US-TEST,AmeriFlux,http://example.com/file.zip?=fluxnetshuttle\n"
         ),
     )
@@ -334,7 +334,7 @@ class TestDownload:
         # Verify that filename passed to _download_dataset has no query params
         mock_download.assert_called_once_with(
             site_id="US-TEST",
-            network="AmeriFlux",
+            data_hub="AmeriFlux",
             filename="file.zip",
             download_link="http://example.com/file.zip?=fluxnetshuttle",
             output_dir=".",
@@ -343,7 +343,7 @@ class TestDownload:
     @patch("os.path.exists")
     @patch(
         "builtins.open",
-        mock_open(read_data="site_id,network,download_link\n" "US-TEST,AmeriFlux,http://example.com/test.zip\n"),
+        mock_open(read_data="site_id,data_hub,download_link\n" "US-TEST,AmeriFlux,http://example.com/test.zip\n"),
     )
     def test_download_site_not_in_snapshot_file_raises_error(self, mock_exists):
         """Test that download raises error when site not in snapshot file."""
@@ -356,7 +356,7 @@ class TestDownload:
         """Test download function with real CSV file but missing site."""
         # Create temporary CSV file
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
-            tmp_file.write("site_id,network,download_link\n")
+            tmp_file.write("site_id,data_hub,download_link\n")
             tmp_file.write("US-Ha1,AmeriFlux,http://example.com/test.zip\n")
             temp_filename = tmp_file.name
 
@@ -396,7 +396,7 @@ class TestListall:
         assert mock_write_header.called
         assert mock_write_header.call_count == 1
         assert mock_write_header.call_args == call()
-        assert not mock_write_row.called  # No rows should be written when no networks are enabled
+        assert not mock_write_row.called  # No rows should be written when no data hubs are enabled
 
     @pytest.mark.asyncio
     @patch("fluxnet_shuttle.shuttle.aiofiles.open")
@@ -404,16 +404,16 @@ class TestListall:
     @patch("fluxnet_shuttle.shuttle.csv.DictWriter.writeheader", new_callable=AsyncMock)
     @patch("fluxnet_shuttle.shuttle.datetime")
     @patch("fluxnet_shuttle.core.shuttle.FluxnetShuttle.get_all_sites", new_callable=MagicMock)
-    async def test_listall_with_networks(
+    async def test_listall_with_data_hubs(
         self, mock_get_all_sites, mock_datetime, mock_write_header, mock_write_row, mock_open
     ):
-        """Test listall with both networks enabled."""
+        """Test listall with both data hubs enabled."""
         mock_get_all_sites.return_value = AsyncMock()
         mock_get_all_sites.return_value.__aiter__.return_value = {
             MagicMock(
                 site_info=MagicMock(
                     site_id="US-TEST",
-                    network="AmeriFlux",
+                    data_hub="AmeriFlux",
                     location_lat=45.0,
                     location_long=-120.0,
                 ),
@@ -426,7 +426,7 @@ class TestListall:
             MagicMock(
                 site_info=MagicMock(
                     site_id="FI-HYY",
-                    network="ICOS",
+                    data_hub="ICOS",
                     location_lat=61.85,
                     location_long=24.29,
                 ),


### PR DESCRIPTION
Resolves #44 by standardizing terminology throughout the codebase from "network" to "data_hub". This change improves clarity as the plugins connect to data hubs (AmeriFlux, ICOS) rather than networks.

Changes:
- Renamed NetworkPlugin to DataHubPlugin in core/base.py
- Updated all references throughout codebase (registry, shuttle, plugins)
- Changed CLI command from 'sources' to 'listdatahubs'
- Updated model attribute from 'network' to 'data_hub' in models.py
- Updated docstrings and comments to reflect new terminology
- Updated all tests to use new naming convention
- No backwards compatibility alias - complete refactor to DataHub terminology