### PR TITLE
feat(ameriflux): migrate to data_download endpoint with user tracking

### DIFF
--- a/src/fluxnet_shuttle/core/base.py
+++ b/src/fluxnet_shuttle/core/base.py
@@ -165,6 +165,28 @@ class DataHubPlugin(ABC):
         """
         pass
 
+    async def prepare_download(self, site_id: str, download_link: str, **kwargs) -> str:
+        """
+        Prepare a download URL for a specific site.
+
+        This optional method allows plugins to customize the download URL
+        (e.g., for user tracking, authentication, or personalized links).
+        The default implementation returns the download_link unchanged.
+
+        Args:
+            site_id: Site identifier
+            download_link: Original download link from site metadata
+            **kwargs: Additional plugin-specific parameters
+
+        Returns:
+            str: Download URL ready to use (may be same as input or customized)
+
+        Raises:
+            PluginError: If preparation fails
+        """
+        # Default implementation: return the original link unchanged
+        return download_link
+
     @asynccontextmanager
     async def _session_request(self, method: str, url: str, **kwargs) -> AsyncGenerator[aiohttp.ClientResponse, None]:
         """

--- a/src/fluxnet_shuttle/main.py
+++ b/src/fluxnet_shuttle/main.py
@@ -193,7 +193,24 @@ def cmd_download(args) -> List[str]:
 
     log.debug(f"Running download command with {len(sites)} site IDs: {sites} and snapshot file: {snapshot_file}")
 
-    downloaded_files = download(site_ids=sites, snapshot_file=snapshot_file, output_dir=output_dir)
+    # Build kwargs from CLI arguments for plugins
+    # Plugins will extract what they need from these kwargs
+    plugin_kwargs = {}
+    if hasattr(args, "user_id") and args.user_id:
+        plugin_kwargs["user_id"] = args.user_id
+    if hasattr(args, "user_email") and args.user_email:
+        plugin_kwargs["user_email"] = args.user_email
+    if hasattr(args, "intended_use") and args.intended_use:
+        plugin_kwargs["intended_use"] = args.intended_use
+    if hasattr(args, "description") and args.description:
+        plugin_kwargs["description"] = args.description
+
+    downloaded_files: List[str] = download(
+        site_ids=sites,
+        snapshot_file=snapshot_file,
+        output_dir=output_dir,
+        **plugin_kwargs,
+    )
     log.info(f"Downloaded {len(downloaded_files)} files")
     return downloaded_files
 
@@ -299,6 +316,34 @@ def main() -> None:
         help="Skip confirmation prompt when downloading all sites",
         action="store_true",
         dest="quiet",
+    )
+    parser_download.add_argument(
+        "--user-id",
+        help="User ID for data hub tracking (required by some data hubs like AmeriFlux)",
+        type=str,
+        dest="user_id",
+        default=None,
+    )
+    parser_download.add_argument(
+        "--user-email",
+        help="User email for data hub tracking (required by some data hubs like AmeriFlux)",
+        type=str,
+        dest="user_email",
+        default=None,
+    )
+    parser_download.add_argument(
+        "--intended-use",
+        help="Intended use for data hub tracking (e.g., synthesis, model, remote_sensing)",
+        type=str,
+        dest="intended_use",
+        default=None,
+    )
+    parser_download.add_argument(
+        "--description",
+        help="Brief description of intended use (optional, used by some data hubs)",
+        type=str,
+        dest="description",
+        default="",
     )
 
     # listdatahubs command

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -562,6 +562,43 @@ class TestCLIFunctions:
         finally:
             os.unlink(csv_file)
 
+    @patch("fluxnet_shuttle.main.download")
+    def test_cmd_download_with_all_plugin_kwargs(self, mock_download):
+        """Test cmd_download with all plugin kwargs (user_id, user_email, intended_use, description)."""
+        mock_download.return_value = []
+
+        # Create a temporary CSV file
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp:
+            tmp.write("site_id,data_hub\nUS-Ha1,AmeriFlux\n")
+            csv_file = tmp.name
+
+        try:
+            args = argparse.Namespace(
+                sites=["US-Ha1"],
+                snapshot_file=csv_file,
+                output_dir=".",
+                user_id="test_user",
+                user_email="test@example.com",
+                intended_use="synthesis",
+                description="Test project",
+                logfile="test.log",
+                no_logfile=False,
+                verbose=False,
+            )
+
+            cmd_download(args)
+
+            # Verify download was called with plugin kwargs
+            mock_download.assert_called_once()
+            call_kwargs = mock_download.call_args[1]
+            assert call_kwargs["user_id"] == "test_user"
+            assert call_kwargs["user_email"] == "test@example.com"
+            assert call_kwargs["intended_use"] == "synthesis"
+            assert call_kwargs["description"] == "Test project"
+
+        finally:
+            os.unlink(csv_file)
+
     def test_cmd_listall_with_output_dir(self):
         """Test cmd_listall with custom output directory."""
         import tempfile

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -206,6 +206,19 @@ class TestDataHubPlugin:
         assert "Unexpected error during HTTP request" in error.message
         assert isinstance(error.original_error, ValueError)
 
+    @pytest.mark.asyncio
+    async def test_default_prepare_download(self):
+        """Test default prepare_download implementation returns original link."""
+        plugin = MockDataHubPlugin()
+
+        # The default implementation should return the original download_link unchanged
+        original_link = "https://example.com/data/file.zip"
+        result = await plugin.prepare_download(
+            site_id="US-TEST", download_link=original_link, user_info={"user_id": "test_user"}
+        )
+
+        assert result == original_link
+
 
 class TestShuttleConfig:
     """Test cases for ShuttleConfig."""


### PR DESCRIPTION
Resolves #46 by updating the AmeriFlux plugin to use the new /api/v2/data_download endpoint which requires user tracking parameters for download attribution.

Changes:
- Updated AmeriFlux plugin endpoint from amf_shuttle_data_files_and_manifest to data_download
- Added user tracking parameters: user_id, user_email, intended_use, description
- Implemented interactive CLI prompts for download command with numbered menu
- Added CLI flags: --user-id, --user-email, --intended-use, --description
- Enhanced download function to re-query API with user credentials for proper tracking
- Updated tests to use new endpoint parameters
- Quiet mode (--quiet) and CLI flags bypass interactive prompts

User Experience:
- listall: No prompts, uses default tracking credentials
- download: Interactive prompts unless --quiet or CLI flags provided
- download --quiet: Uses defaults, no interaction
- download with flags: Uses provided values, no prompts