### PR TITLE
feat: add network and product_source_network fields to metadata models

### DIFF
--- a/src/fluxnet_shuttle/models.py
+++ b/src/fluxnet_shuttle/models.py
@@ -115,6 +115,7 @@ class BadmSiteGeneralInfo(BaseModel):
         location_lat (float): Site latitude in decimal degrees
         location_long (float): Site longitude in decimal degrees
         igbp (str): IGBP land cover type classification
+        network (List[str]): Network affiliation(s) of the site
         group_team_member (List[TeamMember]): List of team member information for this site
     """
 
@@ -153,6 +154,11 @@ class BadmSiteGeneralInfo(BaseModel):
         max_length=10,
     )
 
+    network: List[str] = Field(
+        default_factory=list,
+        description="Network affiliation(s) of the site",
+    )
+
     group_team_member: List[TeamMember] = Field(
         default_factory=list,
         description="List of team member information for this site",
@@ -181,6 +187,7 @@ class DataFluxnetProduct(BaseModel):
         product_citation (str): Citation string for the data product
         product_id (str): Product identifier (e.g., hashtag, DOI, PID)
         code_version (str): ONEFlux code version used in the data processing
+        product_source_network (str): Source network identifier extracted from filename (e.g., AMF, ICOSETC)
     """
 
     model_config = ConfigDict(str_strip_whitespace=True, validate_assignment=True, extra="forbid")
@@ -196,6 +203,10 @@ class DataFluxnetProduct(BaseModel):
     product_id: str = Field(..., description="Product identifier (e.g., hashtag, DOI, PID)")
 
     code_version: str = Field(..., description="ONEFlux code version used in the data processing")
+
+    product_source_network: str = Field(
+        ..., description="Source network identifier extracted from filename (e.g., AMF, ICOSETC)"
+    )
 
     @model_validator(mode="after")
     def validate_year_range(self) -> "DataFluxnetProduct":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -49,6 +49,7 @@ class MockDataHubPlugin(DataHubPlugin):
             product_citation="Test citation",
             product_id="test-id",
             code_version="v1",
+            product_source_network="TEST",
         )
 
         yield FluxnetDatasetMetadata(site_info=site_info, product_data=product_data)

--- a/tests/test_core_shuttle.py
+++ b/tests/test_core_shuttle.py
@@ -71,6 +71,7 @@ class MockSuccessPlugin:
                 product_citation="Test citation",
                 product_id="test-id",
                 code_version="v1",
+                product_source_network="SUCCESS",
             )
 
             yield FluxnetDatasetMetadata(site_info=site_info, product_data=product_data)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,6 +45,7 @@ def sample_product_data():
         product_citation="Test citation",
         product_id="test-id-123",
         code_version="v1",
+        product_source_network="AMF",
     )
 
 
@@ -186,6 +187,7 @@ def test_data_fluxnet_product_year_validation():
             product_citation="Test citation",
             product_id="test-id",
             code_version="v1",
+            product_source_network="AMF",
         )
         assert product.first_year == first_year
         assert product.last_year == last_year
@@ -199,6 +201,7 @@ def test_data_fluxnet_product_year_validation():
             product_citation="Test citation",
             product_id="test-id",
             code_version="v1",
+            product_source_network="AMF",
         )
 
     with pytest.raises(ValidationError):
@@ -209,6 +212,7 @@ def test_data_fluxnet_product_year_validation():
             product_citation="Test citation",
             product_id="test-id",
             code_version="v1",
+            product_source_network="AMF",
         )
 
     # Invalid year range (last_year < first_year)
@@ -220,6 +224,7 @@ def test_data_fluxnet_product_year_validation():
             product_citation="Test citation",
             product_id="test-id",
             code_version="v1",
+            product_source_network="AMF",
         )
 
 
@@ -239,6 +244,7 @@ def test_data_fluxnet_product_url_validation():
             product_citation="Test citation",
             product_id="test-id",
             code_version="v1",
+            product_source_network="AMF",
         )
         assert str(product.download_link) == url
 
@@ -259,6 +265,7 @@ def test_data_fluxnet_product_url_validation():
                 product_citation="Test citation",
                 product_id="test-id",
                 code_version="v1",
+                product_source_network="AMF",
             )
 
 
@@ -289,6 +296,7 @@ def test_fluxnet_dataset_metadata_nested_validation():
                 product_citation="Test citation",
                 product_id="test-id",
                 code_version="v1",
+                product_source_network="AMF",
             ),
         )
 
@@ -310,6 +318,7 @@ def test_fluxnet_dataset_metadata_nested_validation():
                 product_citation="Test citation",
                 product_id="test-id",
                 code_version="v1",
+                product_source_network="AMF",
             ),
         )
 

--- a/tests/test_plugin_ameriflux.py
+++ b/tests/test_plugin_ameriflux.py
@@ -404,7 +404,12 @@ class TestAmeriFluxPlugin:
 
         with pytest.raises(ValueError) as exc_info:
             plugin._build_product_data(
-                [], "http://example.com/test.zip", product_id="test-id", citation="test citation", code_version="v1"
+                [],
+                "http://example.com/test.zip",
+                product_id="test-id",
+                citation="test citation",
+                code_version="v1",
+                product_source_network="AMF",
             )
 
         assert "publish_years cannot be empty" in str(exc_info.value)

--- a/tests/test_shuttle.py
+++ b/tests/test_shuttle.py
@@ -12,7 +12,7 @@ from fluxnet_shuttle.shuttle import (
     _extract_filename_from_headers,
     _extract_filename_from_url,
     download,
-    extract_code_version_from_filename,
+    extract_fluxnet_filename_metadata,
     listall,
     validate_fluxnet_filename_format,
 )
@@ -95,42 +95,48 @@ class TestExtractFilenameFromHeaders:
         assert result is None
 
 
-class TestExtractCodeVersionFromFilename:
-    """Test cases for the extract_code_version_from_filename function."""
+class TestExtractFluxnetFilenameMetadata:
+    """Test cases for the extract_fluxnet_filename_metadata function (combined extraction)."""
 
-    def test_valid_zip_format(self):
-        """Test extracting version from valid ZIP filename."""
+    def test_valid_amf_filename(self):
+        """Test extracting both metadata from AmeriFlux filename."""
         filename = "AMF_US-Ha1_FLUXNET_2005-2012_v3_r7.zip"
-        result = extract_code_version_from_filename(filename)
-        assert result == "v3"
+        source_network, version = extract_fluxnet_filename_metadata(filename)
+        assert source_network == "AMF"
+        assert version == "v3"
 
-    def test_valid_zip_format_with_url(self):
-        """Test extracting version from full URL with ZIP file."""
+    def test_valid_icosetc_filename(self):
+        """Test extracting both metadata from ICOS filename."""
+        filename = "ICOSETC_BE-Bra_FLUXNET_2020-2024_v1.4_r1.zip"
+        source_network, version = extract_fluxnet_filename_metadata(filename)
+        assert source_network == "ICOSETC"
+        assert version == "v1.4"
+
+    def test_valid_filename_with_url(self):
+        """Test extracting both metadata from full URL."""
         url = "https://example.com/AMF_AR-Bal_FLUXNET_2012-2013_v3_r7.zip"
-        result = extract_code_version_from_filename(url)
-        assert result == "v3"
-
-    def test_valid_zip_format_different_version(self):
-        """Test extracting different version number."""
-        filename = "AMF_IT-Niv_FLUXNET_2010-2015_v1_r0.zip"
-        result = extract_code_version_from_filename(filename)
-        assert result == "v1"
+        source_network, version = extract_fluxnet_filename_metadata(url)
+        assert source_network == "AMF"
+        assert version == "v3"
 
     def test_invalid_filename_format(self):
         """Test with filename that doesn't match pattern."""
         filename = "invalid_filename.zip"
-        result = extract_code_version_from_filename(filename)
-        assert result == ""
+        source_network, version = extract_fluxnet_filename_metadata(filename)
+        assert source_network == ""
+        assert version == ""
 
     def test_empty_filename(self):
         """Test with empty filename."""
-        result = extract_code_version_from_filename("")
-        assert result == ""
+        source_network, version = extract_fluxnet_filename_metadata("")
+        assert source_network == ""
+        assert version == ""
 
     def test_none_filename(self):
         """Test with None filename."""
-        result = extract_code_version_from_filename(None)
-        assert result == ""
+        source_network, version = extract_fluxnet_filename_metadata(None)
+        assert source_network == ""
+        assert version == ""
 
 
 class TestValidateFluxnetFilenameFormat:


### PR DESCRIPTION
Add network field to BadmSiteGeneralInfo to track site network memberships. Add product_source_network field to DataFluxnetProduct to identify the source network from filename.

Changes:
- Add network field (List[str]) to BadmSiteGeneralInfo model with default empty list
- Add product_source_network field (str) to DataFluxnetProduct model as required field
- Implement extract_product_source_network_from_filename() helper function
- Update AmeriFlux plugin to populate network from grp_network API field
- Update ICOS plugin to set network as empty list (placeholder)
- Update snapshot CSV export to include both fields with semicolon-delimited network values
- Add comprehensive test coverage for new functionality
- Update all existing tests to include product_source_network field

The network field is populated from AmeriFlux site_info_display API's grp_network field (list of strings). For ICOS, it remains empty until SPARQL query is enhanced.

The product_source_network field is extracted from the first component of FLUXNET filenames (e.g., AMF_US-Ha1_... yields 'AMF').

Resolves issue #40 