### PR TITLE
refactor: remove hardcoded versions and versionadded references

### DIFF
--- a/src/fluxnet_shuttle/__init__.py
+++ b/src/fluxnet_shuttle/__init__.py
@@ -69,11 +69,6 @@ distribute, and sublicense such enhancements or derivative works thereof,
 in binary and source code form.
 
 
-*Version History*
-
-.. versionadded:: 0.1.0
-   Initial release with AmeriFlux and ICOS support.
-
 .. rubric:: Submodules
 .. autosummary::
     :toctree: generated/
@@ -93,8 +88,6 @@ import traceback
 import warnings
 from typing import Optional, Tuple
 
-VERSION = "0.1.0"
-
 __author__ = "Gilberto Pastorello"
 __copyright__ = (
     "Copyright 2023-2024, The Regents of the University of California, " "through Lawrence Berkeley National Laboratory"
@@ -108,7 +101,6 @@ __email__ = "gzpastorello@lbl.gov"
 __institution__ = "Lawrence Berkeley National Laboratory (www.lbl.gov)"
 __license__ = "BSD"
 __status__ = "Development"
-__version__ = VERSION
 
 # get logger for this module
 _log = logging.getLogger(__name__)

--- a/src/fluxnet_shuttle/main.py
+++ b/src/fluxnet_shuttle/main.py
@@ -36,12 +36,6 @@ Download data from AmeriFlux::
 
     fluxnet-shuttle download --source ameriflux --output ./data
 
-Version
--------
-
-.. versionadded:: 0.1.0
-   Initial CLI implementation.
-
 """
 
 import argparse

--- a/src/fluxnet_shuttle/models.py
+++ b/src/fluxnet_shuttle/models.py
@@ -5,7 +5,6 @@ Pydantic Schema Models for FLUXNET Shuttle Library
 :module:: fluxnet_shuttle.models
 :synopsis: Pydantic models for FLUXNET dataset metadata and validation
 :moduleauthor: Valerie Hendrix <vchendrix@lbl.gov>
-:versionadded: 1.0.0
 :platform: Unix, Windows
 :created: 2025-10-09
 
@@ -56,7 +55,6 @@ Note:
     automatic API documentation generation.
 
 .. moduleauthor:: FLUXNET Shuttle Library Team
-.. versionadded:: 1.0.0
 """
 
 import re

--- a/src/fluxnet_shuttle/shuttle.py
+++ b/src/fluxnet_shuttle/shuttle.py
@@ -47,13 +47,6 @@ License
 
 For license information, see LICENSE file or headers in fluxnet_shuttle.__init__.py
 
-
-Version
--------
-
-.. versionadded:: 0.1.0
-   Initial shuttle functionality.
-
 """
 
 import csv
@@ -244,9 +237,6 @@ def _download_dataset(site_id: str, data_hub: str, filename: str, download_link:
 def download(site_ids: Optional[List[str]] = None, snapshot_file: str = "", output_dir: str = ".") -> List[str]:
     """
     Download FLUXNET data for specified sites using configuration from a snapshot file.
-
-    .. versionadded:: 0.1.0
-       Initial download functionality for AmeriFlux and ICOS data hubs.
 
     :param site_ids: List of site IDs to download data for. If None or empty, downloads all sites from snapshot file.
     :type site_ids: Optional[List[str]]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,9 +12,7 @@ from fluxnet_shuttle import (
     LOG_DATEFMT,
     LOG_FMT,
     LOG_LEVELS,
-    VERSION,
     FLUXNETShuttleError,
-    __version__,
     add_file_log,
     format_warning,
     log_config,
@@ -42,24 +40,6 @@ class TestFLUXNETShuttleError:
         """Test that FLUXNETShuttleError inherits from Exception."""
         error = FLUXNETShuttleError("test")
         assert isinstance(error, Exception)
-
-
-class TestVersionConstants:
-    """Test cases for version and metadata constants."""
-
-    def test_version_exists(self):
-        """Test that VERSION constant exists."""
-        assert VERSION is not None
-        assert isinstance(VERSION, str)
-
-    def test_version_format(self):
-        """Test that version follows expected format."""
-        assert VERSION == "0.1.0"
-
-    def test_dunder_version_exists(self):
-        """Test that __version__ exists."""
-        assert __version__ is not None
-        assert __version__ == VERSION
 
 
 class TestLogConfig:
@@ -252,12 +232,6 @@ class TestBasicFunctionality:
         """Test creating custom exception."""
         error = FLUXNETShuttleError("test message")
         assert str(error) == "test message"
-
-    def test_version_constants(self):
-        """Test version constants."""
-        assert VERSION
-        assert __version__
-        assert VERSION == __version__
 
     def test_function_existence(self):
         """Test that all expected functions exist."""


### PR DESCRIPTION
Resolves #53 by removing all hardcoded version constants.

Changes:
- Removed VERSION constant and __version__ from __init__.py
- Removed all ..versionadded and ..versionchanged:
  - src/fluxnet_shuttle/__init__.py
  - src/fluxnet_shuttle/models.py
  - src/fluxnet_shuttle/shuttle.py
  - src/fluxnet_shuttle/main.py
- Updated tests/test_init.py to remove VERSION-related tests
- All existing tests pass after changes