### PR TITLE
feat(ameriflux): implement user tracking for download requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
 docs = [
     "sphinx",
     "sphinx-autodoc-typehints",
-    "sphinx-rtd-theme",
+    "sphinx-rtd-theme>=2.0.0",
 ]
 examples = [
     "pandas>=1.3.0",

--- a/src/fluxnet_shuttle/__init__.py
+++ b/src/fluxnet_shuttle/__init__.py
@@ -86,7 +86,7 @@ import logging
 import sys
 import traceback
 import warnings
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 __author__ = "Gilberto Pastorello"
 __copyright__ = (
@@ -111,7 +111,7 @@ _log.addHandler(logging.NullHandler())
 
 # customize showwarning to get py.warnings to be logged instead of printed and
 # to avoid new line characters in log
-def format_warning(message, category, filename, lineno, file=None, line=None):
+def format_warning(message: Any, category: Any, filename: Any, lineno: Any, file: Any = None, line: Any = None) -> None:
     logger_pywarnings = logging.getLogger("py.warnings")
     if not logger_pywarnings.handlers:
         logger_pywarnings.addHandler(logging.NullHandler())
@@ -143,14 +143,14 @@ class FLUXNETShuttleError(Exception):
 
 
 def log_config(
-    level=logging.DEBUG,
-    filename=None,
-    filename_level=None,
-    std=True,
-    std_level=None,
-    log_fmt=LOG_FMT,
-    log_datefmt=LOG_DATEFMT,
-):
+    level: int = logging.DEBUG,
+    filename: Optional[str] = None,
+    filename_level: Optional[int] = None,
+    std: bool = True,
+    std_level: Optional[int] = None,
+    log_fmt: str = LOG_FMT,
+    log_datefmt: str = LOG_DATEFMT,
+) -> None:
     """
     Setup root logger and handlers for log file and STDOUT
 
@@ -226,7 +226,7 @@ def log_config(
 
 
 def add_file_log(
-    filename, level=logging.DEBUG, log_fmt=LOG_FMT, log_datefmt=LOG_DATEFMT
+    filename: str, level: int = logging.DEBUG, log_fmt: str = LOG_FMT, log_datefmt: str = LOG_DATEFMT
 ) -> Tuple[logging.Logger, Optional[logging.FileHandler]]:
     """
     Setup root logger and handlers for log file and STDOUT
@@ -273,7 +273,7 @@ def add_file_log(
     return logger_root, handler_file
 
 
-def log_trace(exception, level=logging.ERROR, log=_log, output_fmt="std") -> str:
+def log_trace(exception: Exception, level: int = logging.ERROR, log: Any = _log, output_fmt: str = "std") -> str:
     """
     Logs exception including stack traceback into log,
     formatting trace as single line

--- a/src/fluxnet_shuttle/core/http_utils.py
+++ b/src/fluxnet_shuttle/core/http_utils.py
@@ -14,7 +14,7 @@ HTTP utilities for making API requests and handling responses
 
 import logging
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 
 import aiohttp
 
@@ -54,7 +54,7 @@ async def get_session() -> AsyncGenerator[aiohttp.ClientSession, None]:
 async def session_request(
     method: str,
     url: str,
-    **kwargs,
+    **kwargs: Any,
 ) -> AsyncGenerator[aiohttp.ClientResponse, None]:
     """
     Make an HTTP request using the provided aiohttp ClientSession.

--- a/src/fluxnet_shuttle/core/registry.py
+++ b/src/fluxnet_shuttle/core/registry.py
@@ -18,7 +18,7 @@ and error collection capabilities.
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import AsyncGenerator, Dict, List, Type
+from typing import Any, AsyncGenerator, Dict, List, Type
 
 from ..models import ErrorSummary, FluxnetDatasetMetadata, PluginErrorDetail
 from .base import DataHubPlugin
@@ -44,7 +44,7 @@ class ErrorCollectingIterator:
     from multiple plugins while isolating and collecting any errors that occur.
     """
 
-    def __init__(self, plugins: Dict[str, DataHubPlugin], operation: str, **kwargs):
+    def __init__(self, plugins: Dict[str, DataHubPlugin], operation: str, **kwargs: Any) -> None:
         """
         Initialize the error collecting iterator.
 
@@ -61,7 +61,7 @@ class ErrorCollectingIterator:
         self._plugin_iterators: Dict[str, AsyncGenerator[FluxnetDatasetMetadata, None]] = {}
         self._completed_plugins: set[str] = set()
 
-    def __aiter__(self):
+    def __aiter__(self) -> "ErrorCollectingIterator":
         """Return self as the async iterator."""
         return self
 
@@ -136,7 +136,7 @@ class ErrorCollectingIterator:
         # No more results from any plugin
         raise StopAsyncIteration
 
-    def add_error(self, plugin_name: str, error: Exception, operation: str = ""):
+    def add_error(self, plugin_name: str, error: Exception, operation: str = "") -> None:
         """
         Add an error to the collection.
 
@@ -189,7 +189,7 @@ class PluginRegistry:
     including automatic discovery through entry points.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the plugin registry."""
         self._plugins: Dict[str, Type[DataHubPlugin]] = {}
         self._instances: Dict[str, DataHubPlugin] = {}
@@ -244,7 +244,7 @@ class PluginRegistry:
         """
         return list(self._plugins.keys())
 
-    def create_instance(self, name: str, **config) -> DataHubPlugin:
+    def create_instance(self, name: str, **config: Any) -> DataHubPlugin:
         """
         Create an instance of a plugin.
 

--- a/src/fluxnet_shuttle/core/shuttle.py
+++ b/src/fluxnet_shuttle/core/shuttle.py
@@ -22,6 +22,7 @@ from fluxnet_shuttle.core.decorators import async_to_sync_generator
 from fluxnet_shuttle.core.registry import ErrorCollectingIterator, registry
 
 from ..models import ErrorSummary, FluxnetDatasetMetadata
+from .base import DataHubPlugin
 from .config import ShuttleConfig
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ class FluxnetShuttle:
         logger.info(f"Initialized FluxnetShuttle with data hubs: {self.data_hubs}")
 
     @async_to_sync_generator
-    async def get_all_sites(self, **filters) -> AsyncGenerator[FluxnetDatasetMetadata, None]:
+    async def get_all_sites(self, **filters: Any) -> AsyncGenerator[FluxnetDatasetMetadata, None]:
         """
         Get sites from all enabled data hubs.
 
@@ -126,7 +127,7 @@ class FluxnetShuttle:
 
         return plugins
 
-    def _get_plugin_instance(self, data_hub_name: str):
+    def _get_plugin_instance(self, data_hub_name: str) -> DataHubPlugin:
         """
         Get a plugin instance for the specified data hub.
 

--- a/src/fluxnet_shuttle/models.py
+++ b/src/fluxnet_shuttle/models.py
@@ -184,9 +184,10 @@ class DataFluxnetProduct(BaseModel):
         download_link (HttpUrl): URL for downloading the data product
         product_citation (str): Citation string for the data product
         product_id (str): Product identifier (e.g., hashtag, DOI, PID)
-        oneflux_code_version (str): ONEFlux processing code used, extracted from filename
+        oneflux_code_version (str): ONEFlux processing code used, extracted from fluxnet_product_name
             (major.minor version designation only)
-        product_source_network (str): Source network identifier extracted from filename (e.g., AMF, ICOSETC)
+        product_source_network (str): Source network identifier extracted from fluxnet_product_name (e.g., AMF, ICOSETC)
+        fluxnet_product_name (str): Name of the FLUXNET data product file
     """
 
     model_config = ConfigDict(str_strip_whitespace=True, validate_assignment=True, extra="forbid")
@@ -202,11 +203,19 @@ class DataFluxnetProduct(BaseModel):
     product_id: str = Field(..., description="Product identifier (e.g., hashtag, DOI, PID)")
 
     oneflux_code_version: str = Field(
-        ..., description="ONEFlux processing code used, extracted from filename (major.minor version designation only)"
+        ...,
+        description=(
+            "ONEFlux processing code used, extracted from fluxnet_product_name "
+            "(major.minor version designation only)"
+        ),
     )
 
     product_source_network: str = Field(
-        ..., description="Source network identifier extracted from filename (e.g., AMF, ICOSETC)"
+        ..., description="Source network identifier extracted from fluxnet_product_name (e.g., AMF, ICOSETC)"
+    )
+
+    fluxnet_product_name: str = Field(
+        ..., description="Name of the FLUXNET data product file", min_length=1, max_length=255
     )
 
     @model_validator(mode="after")

--- a/src/fluxnet_shuttle/plugins/icos.py
+++ b/src/fluxnet_shuttle/plugins/icos.py
@@ -7,7 +7,7 @@ ICOS Carbon Portal data hub implementation for the FLUXNET Shuttle plugin system
 
 import asyncio
 import logging
-from typing import Any, AsyncGenerator, Dict, Generator, Optional
+from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Tuple
 
 from ..core.base import DataHubPlugin
 from ..core.decorators import async_to_sync_generator
@@ -134,7 +134,7 @@ class ICOSPlugin(DataHubPlugin):
                 await asyncio.sleep(0.001)  # Yield control to event loop
                 yield site_data
 
-    def _group_sparql_bindings(self, bindings: list) -> Dict[str, Dict[str, Any]]:
+    def _group_sparql_bindings(self, bindings: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
         """Group SPARQL bindings by data object URI and collect team members."""
         sites_data: Dict[str, Dict[str, Any]] = {}
 
@@ -190,7 +190,7 @@ class ICOSPlugin(DataHubPlugin):
             team_member_email=binding.get("email", {}).get("value", ""),
         )
 
-    def _parse_coordinates(self, station_id: str, lat_value: Any, lon_value: Any) -> tuple:
+    def _parse_coordinates(self, station_id: str, lat_value: Any, lon_value: Any) -> Tuple[float, float]:
         """Parse and validate latitude and longitude coordinates."""
         location_lat = 0.0
         location_long = 0.0
@@ -209,7 +209,7 @@ class ICOSPlugin(DataHubPlugin):
 
         return location_lat, location_long
 
-    def _parse_year_range(self, time_start: str, time_end: str) -> tuple:
+    def _parse_year_range(self, time_start: str, time_end: str) -> Tuple[int, int]:
         """Parse year range from time strings."""
         first_year = 2000  # Default
         last_year = 2020  # Default
@@ -295,6 +295,7 @@ class ICOSPlugin(DataHubPlugin):
                     product_id=download_id,
                     oneflux_code_version=oneflux_code_version,
                     product_source_network=product_source_network,
+                    fluxnet_product_name=filename,
                 )
 
                 yield FluxnetDatasetMetadata(site_info=site_info, product_data=product_data)

--- a/tests/test_core_shuttle.py
+++ b/tests/test_core_shuttle.py
@@ -72,6 +72,7 @@ class MockSuccessPlugin:
                 product_id="test-id",
                 oneflux_code_version="v1",
                 product_source_network="SUCCESS",
+                fluxnet_product_name="SUCCESS_US-SUCCESS_FLUXNET_2019-2020_v1_r0.zip",
             )
 
             yield FluxnetDatasetMetadata(site_info=site_info, product_data=product_data)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -46,6 +46,7 @@ def sample_product_data():
         product_id="test-id-123",
         oneflux_code_version="v1",
         product_source_network="AMF",
+        fluxnet_product_name="test_file.zip",
     )
 
 
@@ -188,6 +189,7 @@ def test_data_fluxnet_product_year_validation():
             product_id="test-id",
             oneflux_code_version="v1",
             product_source_network="AMF",
+            fluxnet_product_name="test_file.zip",
         )
         assert product.first_year == first_year
         assert product.last_year == last_year
@@ -202,6 +204,7 @@ def test_data_fluxnet_product_year_validation():
             product_id="test-id",
             oneflux_code_version="v1",
             product_source_network="AMF",
+            fluxnet_product_name="test_file.zip",
         )
 
     with pytest.raises(ValidationError):
@@ -213,6 +216,7 @@ def test_data_fluxnet_product_year_validation():
             product_id="test-id",
             oneflux_code_version="v1",
             product_source_network="AMF",
+            fluxnet_product_name="test_file.zip",
         )
 
     # Invalid year range (last_year < first_year)
@@ -225,6 +229,7 @@ def test_data_fluxnet_product_year_validation():
             product_id="test-id",
             oneflux_code_version="v1",
             product_source_network="AMF",
+            fluxnet_product_name="test_file.zip",
         )
 
 
@@ -245,6 +250,7 @@ def test_data_fluxnet_product_url_validation():
             product_id="test-id",
             oneflux_code_version="v1",
             product_source_network="AMF",
+            fluxnet_product_name="test_file.zip",
         )
         assert str(product.download_link) == url
 
@@ -266,6 +272,7 @@ def test_data_fluxnet_product_url_validation():
                 product_id="test-id",
                 oneflux_code_version="v1",
                 product_source_network="AMF",
+                fluxnet_product_name="test_file.zip",
             )
 
 
@@ -297,6 +304,7 @@ def test_fluxnet_dataset_metadata_nested_validation():
                 product_id="test-id",
                 oneflux_code_version="v1",
                 product_source_network="AMF",
+                fluxnet_product_name="test_file.zip",
             ),
         )
 
@@ -319,6 +327,7 @@ def test_fluxnet_dataset_metadata_nested_validation():
                 product_id="test-id",
                 oneflux_code_version="v1",
                 product_source_network="AMF",
+                fluxnet_product_name="test_file.zip",
             ),
         )
 


### PR DESCRIPTION
Add comprehensive user tracking functionality for AmeriFlux downloads
using the AmeriFlux data request API. Enhance type safety across the
codebase by adding missing type annotations to resolve all mypy errors.

Changes:
- Interactive user info prompts for AmeriFlux downloads
  * Replace CLI arguments with interactive prompts for better UX
  * Add --quiet flag to bypass prompts for automated workflows
  * Collect: user name, email, intended use, and description
  * Default values: intended_use=6 (Other), description provided
- AmeriFlux user tracking implementation
  * Add IntendedUse enum for tracking codes (1-6)
  * Create AmeriFluxTrackingData Pydantic model
  * Implement async download_stream with tracking integration
  * Non-blocking tracking (failures logged as warnings)
  * Track downloads per file via AmeriFlux data request API
- ICOS filename validation
  * Override download_stream in ICOSPlugin
  * Validate filename from Content-Disposition header
  * Log warnings for filename mismatches
- Type safety improvements
  * Add type annotations to all decorator functions
  * Fix **kwargs type hints across all plugin methods
  * Add missing imports (Any, List, Tuple, etc.)
  * Resolve all 45 mypy type errors across 9 files
- Refactor download functions for flexibility
  * Use **kwargs pattern instead of explicit user_info param
  * Enable plugin-specific parameter handling
  * Maintain backward compatibility

Technical details:
- Uses plugin-specific user_info dict: {"ameriflux": {...}}
- Graceful error handling for tracking endpoint failures
- All tests passing with comprehensive coverage
- Code formatted with black and passes all CI checks

Resolves https://github.com/AMF-FLX/fluxnet-shuttle-lib/issues/46
Resolves https://github.com/AMF-FLX/fluxnet-shuttle-lib/issues/61
Resolves https://github.com/AMF-FLX/fluxnet-shuttle-lib/issues/62