### PR TITLE
fix: resolve mypy type checking errors and configuration issues

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,14 +1,18 @@
+# MyPy configuration for FLUXNET Shuttle Library
+# Enables all strictness options for main source code
+# Enforces type annotations in test files
+
 [mypy]
 python_version = 3.13
 files = src/fluxnet_shuttle,tests
-ignore_missing_imports = true
-strict = true # Enables all strictness options
-show_error_codes = true
-pretty = true
-warn_unused_ignores = true
-warn_return_any = true
-warn_unused_configs = true
+ignore_missing_imports = True
+strict = True
+show_error_codes = True
+pretty = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unused_configs = True
 exclude = ^docs/|^build/|^dist/|^\.venv/|^tests/|^migrations/
 
 [mypy-tests.*]
-disallow_untyped_defs = true  # Enforce type annotations in test files
+disallow_untyped_defs = True

--- a/src/fluxnet_shuttle/core/shuttle.py
+++ b/src/fluxnet_shuttle/core/shuttle.py
@@ -100,8 +100,9 @@ class FluxnetShuttle:
         Returns:
             ErrorSummary: Pydantic model containing error summary information
         """
-        if self._last_error_collector:
-            return self._last_error_collector.get_error_summary()
+        if self._last_error_collector is not None:
+            summary: ErrorSummary = self._last_error_collector.get_error_summary()
+            return summary
         return ErrorSummary(total_errors=0, total_results=0, errors=[])
 
     def list_available_data_hubs(self) -> List[str]:
@@ -111,7 +112,8 @@ class FluxnetShuttle:
         Returns:
             List of available data hub names
         """
-        return self.registry.list_plugins()
+        plugins: List[str] = self.registry.list_plugins()
+        return plugins
 
     def _get_enabled_plugins(self) -> Dict[str, Any]:
         """
@@ -147,4 +149,5 @@ class FluxnetShuttle:
         if not data_hub_config.enabled:
             raise ValueError(f"Data hub '{data_hub_name}' is disabled.")
 
-        return self.registry.create_instance(data_hub_name, **data_hub_config.__dict__)
+        plugin: DataHubPlugin = self.registry.create_instance(data_hub_name, **data_hub_config.__dict__)
+        return plugin


### PR DESCRIPTION
Fixed mypy.ini boolean configuration syntax errors (lowercase 'true' to uppercase 'True') and added explicit type annotations in shuttle.py to resolve no-any-return errors in get_errors(), list_available_data_hubs(), and _get_plugin_instance() methods.

Resolves #66 