### PR TITLE
feat(tern): add TERN data hub plugin with complete implementation 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ fluxnet-shuttle = "fluxnet_shuttle.main:main"
 [project.entry-points."fluxnet_shuttle.plugins"]
 ameriflux = "fluxnet_shuttle.plugins.ameriflux:AmeriFluxPlugin"
 icos = "fluxnet_shuttle.plugins.icos:ICOSPlugin"
+tern = "fluxnet_shuttle.plugins.tern:TERNPlugin"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/fluxnet_shuttle/core/config.py
+++ b/src/fluxnet_shuttle/core/config.py
@@ -39,7 +39,7 @@ class ShuttleConfig:
     """Main shuttle configuration."""
 
     data_hubs: Dict[str, DataHubConfig] = field(default_factory=dict)
-    parallel_requests: int = 2
+    parallel_requests: int = 3
 
     @classmethod
     def load_default(cls) -> "ShuttleConfig":
@@ -127,11 +127,11 @@ class ShuttleConfig:
     def _get_hardcoded_defaults(cls) -> Dict[str, Any]:
         """Get hardcoded default configuration."""
         return {
-            "parallel_requests": 2,
+            "parallel_requests": 3,
             "data_hubs": {
                 "ameriflux": {"enabled": True},
                 "icos": {"enabled": True},
-                "fluxnet2015": {"enabled": False},
+                "tern": {"enabled": True},
             },
         }
 

--- a/src/fluxnet_shuttle/plugins/__init__.py
+++ b/src/fluxnet_shuttle/plugins/__init__.py
@@ -15,5 +15,6 @@ FLUXNET data sources.
 # Import plugins to trigger auto-registration
 from .ameriflux import AmeriFluxPlugin  # noqa: F401
 from .icos import ICOSPlugin  # noqa: F401
+from .tern import TERNPlugin  # noqa: F401
 
-__all__ = ["AmeriFluxPlugin", "ICOSPlugin"]
+__all__ = ["AmeriFluxPlugin", "ICOSPlugin", "TERNPlugin"]

--- a/src/fluxnet_shuttle/plugins/ameriflux.py
+++ b/src/fluxnet_shuttle/plugins/ameriflux.py
@@ -379,7 +379,8 @@ class AmeriFluxPlugin(DataHubPlugin):
 
                 # Extract both product source network and code version from download URL in one pass
                 # URL path typically contains the filename at the end
-                product_source_network, oneflux_code_version = extract_fluxnet_filename_metadata(download_link)
+                # Note: We ignore the year range and run here since AmeriFlux provides years via the API
+                product_source_network, oneflux_code_version, _, _, _ = extract_fluxnet_filename_metadata(download_link)
 
                 # Get citation for this site
                 citation = citations.get(site_id, "")

--- a/src/fluxnet_shuttle/plugins/config.yaml
+++ b/src/fluxnet_shuttle/plugins/config.yaml
@@ -2,7 +2,7 @@
 # ====================================
 
 # Global settings
-parallel_requests: 2
+parallel_requests: 3
 
 # Data hub-specific configurations
 data_hubs:
@@ -10,4 +10,7 @@ data_hubs:
     enabled: true
 
   icos:
+    enabled: true
+
+  tern:
     enabled: true

--- a/src/fluxnet_shuttle/plugins/icos.py
+++ b/src/fluxnet_shuttle/plugins/icos.py
@@ -272,7 +272,8 @@ class ICOSPlugin(DataHubPlugin):
                 download_id = dobj_uri.split("/")[-1]
                 download_link = f"https://data.icos-cp.eu/licence_accept?ids=%5B%22{download_id}%22%5D"
                 # Extract both product source network and code version from filename in one pass
-                product_source_network, oneflux_code_version = extract_fluxnet_filename_metadata(filename)
+                # Note: We ignore the year range and run here since ICOS provides years via the SPARQL API
+                product_source_network, oneflux_code_version, _, _, _ = extract_fluxnet_filename_metadata(filename)
                 citation = site_data["citation"]
 
                 # Skip site if citation is not available

--- a/src/fluxnet_shuttle/plugins/tern.py
+++ b/src/fluxnet_shuttle/plugins/tern.py
@@ -1,0 +1,603 @@
+"""
+TERN Data Hub Plugin
+====================
+
+TERN (Terrestrial Ecosystem Research Network) data hub implementation
+for the FLUXNET Shuttle plugin system.
+
+This plugin handles:
+- BADM SGI metadata from BIF (BADM Interchange Format) files
+- FLUXNET Data Product information from separate text files
+- Parsing grouped metadata elements (e.g., team members)
+"""
+
+import asyncio
+import csv
+import logging
+from collections import defaultdict
+from io import StringIO
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+from fluxnet_shuttle.core.exceptions import PluginError
+
+from ..core.base import DataHubPlugin
+from ..core.decorators import async_to_sync_generator
+from ..models import (
+    BadmSiteGeneralInfo,
+    DataFluxnetProduct,
+    FluxnetDatasetMetadata,
+    TeamMember,
+)
+from ..shuttle import (
+    _extract_filename_from_url,
+    extract_fluxnet_filename_metadata,
+)
+
+logger = logging.getLogger(__name__)
+
+# TERN data endpoints
+TERN_BASE_URL = "https://dap.tern.org.au/thredds/fileServer/ecosystem_process/fluxnet/"
+TERN_BIF_METADATA_URL = f"{TERN_BASE_URL}BIF_all_sites.csv"
+TERN_PRODUCT_METADATA_URL = f"{TERN_BASE_URL}TERN_THREDDS_catalogue.csv"
+
+# BIF file column names
+BIF_COLUMNS = ["SITE_ID", "GROUP_ID", "VARIABLE_GROUP", "VARIABLE", "DATAVALUE"]
+
+
+def _is_newer_product(
+    current_version: tuple[int, ...],
+    current_run: int,
+    latest_version: Optional[tuple[int, ...]],
+    latest_run: Optional[int],
+) -> bool:
+    """
+    Determine if a product is newer than the current latest product.
+
+    Comparison logic:
+    1. Compare major version numbers first (e.g., v2 > v1)
+    2. If major versions equal, compare minor versions (e.g., v1.3 > v1.2)
+    3. Continue for all version parts (patch, etc.)
+    4. If all version parts equal, compare run numbers (e.g., r2 > r1)
+
+    Args:
+        current_version: Version tuple of current product (e.g., (1, 3) for v1.3)
+        current_run: Run number of current product (e.g., 2 for r2)
+        latest_version: Version tuple of latest product found so far (None if first)
+        latest_run: Run number of latest product found so far (None if first)
+
+    Returns:
+        True if current product is newer than latest, False otherwise
+
+    Examples:
+        >>> _is_newer_product((1, 3), 1, (1, 2), 1)  # v1.3 > v1.2
+        True
+        >>> _is_newer_product((1, 3), 2, (1, 3), 1)  # v1.3.r2 > v1.3.r1
+        True
+        >>> _is_newer_product((2, 0), 1, (1, 9), 1)  # v2.0 > v1.9
+        True
+    """
+    # If no latest product exists yet, current is always newer
+    if latest_version is None or latest_run is None:
+        return True
+
+    # FLUXNET versions currently follow a 2-part pattern (major.minor)
+    # e.g., v1.3, v2.0, etc. Compare each part explicitly.
+
+    # Compare major version (index 0)
+    if len(current_version) > 0 and len(latest_version) > 0:
+        current_major = current_version[0]
+        latest_major = latest_version[0]
+
+        if current_major > latest_major:
+            return True
+        elif current_major < latest_major:
+            return False
+        # If major versions equal, continue to minor
+
+    # Compare minor version (index 1) if both versions have it
+    if len(current_version) > 1 and len(latest_version) > 1:
+        current_minor = current_version[1]
+        latest_minor = latest_version[1]
+
+        if current_minor > latest_minor:
+            return True
+        elif current_minor < latest_minor:
+            return False
+        # If minor versions equal, continue to run number
+
+    # All version parts are equal, compare run numbers
+    return current_run > latest_run
+
+
+class BIFParser:
+    """
+    Parser for BADM Interchange Format (BIF) files.
+
+    BIF files contain BADM metadata in a CSV format with columns:
+    SITE_ID, GROUP_ID, VARIABLE_GROUP, VARIABLE, DATAVALUE
+
+    The GROUP_ID identifies related elements (e.g., all fields for one team member).
+    """
+
+    @staticmethod
+    def parse_bif_content(content: str) -> Dict[str, Dict[str, Dict[str, List[Dict[str, str]]]]]:
+        """
+        Parse BIF file content into structured metadata.
+
+        Args:
+            content: BIF file content as string
+
+        Returns:
+            Nested dictionary structure:
+            {
+                site_id: {
+                    group_id: {
+                        variable_group: [
+                            {variable: datavalue, ...},
+                            ...
+                        ]
+                    }
+                }
+            }
+        """
+        reader = csv.DictReader(StringIO(content))
+
+        # Validate header
+        if not reader.fieldnames or set(reader.fieldnames) != set(BIF_COLUMNS):
+            raise ValueError(f"Invalid BIF file format. Expected columns: {BIF_COLUMNS}, got: {reader.fieldnames}")
+
+        # Structure: site_id -> group_id -> variable_group -> list of {variable: datavalue}
+        parsed_data: Dict[str, Dict[str, Dict[str, List[Dict[str, str]]]]] = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(list))
+        )
+
+        for row in reader:
+            site_id = row["SITE_ID"]
+            group_id = row["GROUP_ID"]
+            variable_group = row["VARIABLE_GROUP"]
+            variable = row["VARIABLE"]
+            datavalue = row["DATAVALUE"]
+
+            # Combine site_id with group_id to ensure uniqueness across sites
+            # This handles the case where GROUP_IDs might only be unique within a site
+            unique_group_key = f"{site_id}_{group_id}"
+
+            parsed_data[site_id][unique_group_key][variable_group].append({variable: datavalue})
+
+        return parsed_data
+
+    @staticmethod
+    def extract_site_metadata(  # noqa: C901
+        site_id: str, site_data: Dict[str, Dict[str, List[Dict[str, str]]]]
+    ) -> Dict[str, Any]:
+        """
+        Extract structured metadata for a single site from parsed BIF data.
+
+        Args:
+            site_id: Site identifier
+            site_data: Parsed BIF data for this site (group_id -> variable_group -> data)
+
+        Returns:
+            Dictionary with structured site metadata including:
+            - site_name
+            - location_lat, location_long
+            - igbp
+            - network (list)
+            - team_members (list of dicts)
+            - utc_offset
+        """
+        metadata: Dict[str, Any] = {
+            "site_id": site_id,
+            "site_name": "",
+            "location_lat": 0.0,
+            "location_long": 0.0,
+            "igbp": "UNK",
+            "network": [],
+            "team_members": [],
+            "utc_offset": None,
+        }
+
+        # Iterate through all groups for this site
+        for group_id, group_data in site_data.items():
+            # Process HEADER group
+            if "HEADER" in group_data:
+                for item in group_data["HEADER"]:
+                    if "SITE_NAME" in item:
+                        metadata["site_name"] = item["SITE_NAME"]
+
+            # Process LOCATION group
+            if "LOCATION" in group_data:
+                for item in group_data["LOCATION"]:
+                    # Process latitude and longitude fields
+                    for field_name, metadata_key, display_name in [
+                        ("LOCATION_LAT", "location_lat", "latitude"),
+                        ("LOCATION_LONG", "location_long", "longitude"),
+                    ]:
+                        if field_name in item:
+                            try:
+                                metadata[metadata_key] = float(item[field_name])
+                            except (ValueError, TypeError):
+                                logger.warning(f"Invalid {display_name} for site {site_id}: {item[field_name]}")
+
+            # Process IGBP group
+            if "IGBP" in group_data:
+                for item in group_data["IGBP"]:
+                    if "IGBP" in item:
+                        metadata["igbp"] = item["IGBP"]
+
+            # Process NETWORK group (can have multiple entries)
+            if "NETWORK" in group_data:
+                for item in group_data["NETWORK"]:
+                    network = item.get("NETWORK")
+                    if network and network not in metadata["network"]:
+                        metadata["network"].append(network)
+
+            # Process TEAM_MEMBER group (grouped by GROUP_ID)
+            # Note: A group can contain multiple team members (rows with same GROUP_ID)
+            # We need to group by each occurrence of TEAM_MEMBER_NAME to separate individuals
+            if "TEAM_MEMBER" in group_data:
+                current_member: Dict[str, str] = {}
+                for item in group_data["TEAM_MEMBER"]:
+                    # When we encounter a name, it signals a new team member
+                    if "TEAM_MEMBER_NAME" in item:
+                        # Save previous member if exists
+                        if current_member.get("name"):
+                            metadata["team_members"].append(current_member)
+                        # Start new member
+                        current_member = {"name": item["TEAM_MEMBER_NAME"], "role": "", "email": ""}
+                    elif "TEAM_MEMBER_ROLE" in item:
+                        if current_member:
+                            current_member["role"] = item["TEAM_MEMBER_ROLE"]
+                    elif "TEAM_MEMBER_EMAIL" in item:
+                        if current_member:
+                            current_member["email"] = item["TEAM_MEMBER_EMAIL"]
+
+                # Add the last team member
+                if current_member.get("name"):
+                    metadata["team_members"].append(current_member)
+
+            # Process UTC_OFFSET group
+            if "UTC_OFFSET" in group_data:
+                for item in group_data["UTC_OFFSET"]:
+                    if "UTC_OFFSET" in item:
+                        try:
+                            metadata["utc_offset"] = float(item["UTC_OFFSET"])
+                        except (ValueError, TypeError):
+                            logger.warning(f"Invalid UTC offset for site {site_id}: {item['UTC_OFFSET']}")
+
+        return metadata
+
+
+class TERNPlugin(DataHubPlugin):
+    """TERN data hub plugin implementation."""
+
+    @property
+    def name(self) -> str:
+        return __name__.split(".")[-1]
+
+    @property
+    def display_name(self) -> str:
+        return "TERN"
+
+    @async_to_sync_generator
+    async def get_sites(self, **filters: Any) -> AsyncGenerator[FluxnetDatasetMetadata, None]:
+        """
+        Get TERN sites with FLUXNET data.
+
+        This method:
+        1. Fetches BIF file containing BADM Site General Information
+        2. Fetches FLUXNET product metadata file
+        3. Combines the data to yield FluxnetDatasetMetadata objects
+
+        Args:
+            **filters: Optional filters (not used in this implementation)
+
+        Yields:
+            FluxnetDatasetMetadata: Site metadata objects
+        """
+        logger.info("Fetching TERN sites...")
+
+        try:
+            # Fetch BIF metadata
+            bif_metadata = await self._fetch_bif_metadata()
+
+            # Fetch product metadata
+            product_metadata = await self._fetch_product_metadata()
+
+            # Combine and yield results
+            async for site_data in self._combine_metadata(bif_metadata, product_metadata):
+                await asyncio.sleep(0.001)  # Yield control to event loop
+                yield site_data
+
+        except Exception as e:
+            logger.exception("Failed to retrieve TERN data: %s", e)
+            raise PluginError(self.name, f"Failed to retrieve data: {e}", original_error=e)
+
+    async def _fetch_bif_metadata(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Fetch and parse BIF metadata file.
+
+        Returns:
+            Dictionary mapping site_id to parsed site metadata
+
+        Raises:
+            PluginError: If fetching or parsing fails
+        """
+        logger.info(f"Fetching BIF metadata from {TERN_BIF_METADATA_URL}")
+
+        try:
+            async with self._session_request("GET", TERN_BIF_METADATA_URL) as response:
+                content = await response.text()
+
+                # Parse BIF content
+                parser = BIFParser()
+                parsed_data = parser.parse_bif_content(content)
+
+                # Extract structured metadata for each site
+                site_metadata = {}
+                for site_id, site_data in parsed_data.items():
+                    site_metadata[site_id] = parser.extract_site_metadata(site_id, site_data)
+
+                logger.info(f"Successfully parsed BIF metadata for {len(site_metadata)} sites")
+                return site_metadata
+
+        except PluginError:
+            raise
+        except Exception as e:
+            logger.error(f"Error fetching BIF metadata: {e}")
+            raise PluginError(self.name, f"Failed to fetch BIF metadata: {e}", original_error=e)
+
+    async def _fetch_product_metadata(self) -> Dict[str, List[Dict[str, Any]]]:
+        """
+        Fetch FLUXNET product metadata file.
+
+        File format:
+        SITE_ID,PRODUCT_URL,PRODUCT_ID,PRODUCT_CITATION
+        AU-Lox,https://...,doi:...,Citation text...
+
+        Returns:
+            Dictionary mapping site_id to list of all available products for that site.
+            Selection of the best product happens later in _combine_metadata.
+
+        Raises:
+            PluginError: If fetching or parsing fails
+        """
+        logger.info(f"Fetching product metadata from {TERN_PRODUCT_METADATA_URL}")
+
+        try:
+            async with self._session_request("GET", TERN_PRODUCT_METADATA_URL) as response:
+                content = await response.text()
+
+                # Parse product metadata (returns all products per site, no selection yet)
+                product_data = self._parse_products(content)
+
+                logger.info(f"Successfully parsed product metadata for {len(product_data)} sites")
+                return product_data
+
+        except PluginError:
+            raise
+        except Exception as e:
+            logger.error(f"Error fetching product metadata: {e}")
+            raise PluginError(self.name, f"Failed to fetch product metadata: {e}", original_error=e)
+
+    @staticmethod
+    def _parse_products(content: str) -> Dict[str, List[Dict[str, Any]]]:
+        """
+        Parse product metadata file and group by site.
+
+        File format:
+        SITE_ID,PRODUCT_URL,PRODUCT_ID,PRODUCT_CITATION
+
+        Args:
+            content: File content as string
+
+        Returns:
+            Dictionary mapping site_id to list of all products for that site
+        """
+        reader = csv.DictReader(StringIO(content))
+
+        # Group products by site_id
+        products_by_site: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+
+        for row in reader:
+            site_id = row.get("SITE_ID", "").strip()
+            product_url = row.get("PRODUCT_URL", "").strip()
+            product_id = row.get("PRODUCT_ID", "").strip()
+            product_citation = row.get("PRODUCT_CITATION", "").strip()
+
+            if not site_id or not product_url:
+                continue
+
+            products_by_site[site_id].append(
+                {
+                    "product_url": product_url,
+                    "product_id": product_id,
+                    "product_citation": product_citation,
+                }
+            )
+
+        return dict(products_by_site)
+
+    @staticmethod
+    def _select_latest_product_version(products: List[Dict[str, Any]], site_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Select the latest run of the most recent version from a list of products
+        and return the product with parsed filename components.
+
+        Selection criteria (in order):
+        1. Valid FLUXNET filename format
+        2. Highest version number (e.g., v1.3 > v1.2)
+        3. Highest run number within that version (e.g., r2 > r1)
+
+        Args:
+            products: List of product dictionaries with 'product_url' key
+            site_id: Site identifier (for logging)
+
+        Returns:
+            Dictionary containing:
+            - product: Original product dict
+            - filename: Extracted filename
+            - product_source_network: Network code from filename
+            - oneflux_code_version: Version string
+            - first_year: First year of data
+            - last_year: Last year of data
+            - version_tuple: Parsed version tuple (for comparison)
+            - run_num: Run number (for comparison)
+            Returns None if no valid products found
+        """
+        latest_product: Optional[Dict[str, Any]] = None
+
+        for product in products:
+            url = product["product_url"]
+            filename = _extract_filename_from_url(url)
+
+            # Extract all metadata from filename (validates format internally)
+            product_source_network, version, first_year, last_year, run = extract_fluxnet_filename_metadata(filename)
+
+            # Skip if validation failed
+            if not version or not run:
+                logger.debug(
+                    f"Skipping product for {site_id} - filename does not follow standard format "
+                    f"(<network_id>_<site_id>_FLUXNET_<year_range>_<version>_<run>.<extension>): {filename}"
+                )
+                continue
+
+            # Parse version number (e.g., "v1.3" -> (1, 3))
+            version_parts = version.lower().replace("v", "").split(".")
+            version_tuple = tuple(int(p) for p in version_parts)
+
+            # Parse run number (e.g., "r2" -> 2)
+            run_num = int(run.lower().replace("r", ""))
+
+            # Keep track of the latest product found so far
+            if _is_newer_product(
+                current_version=version_tuple,
+                current_run=run_num,
+                latest_version=latest_product["version_tuple"] if latest_product else None,
+                latest_run=latest_product["run_num"] if latest_product else None,
+            ):
+                latest_product = {
+                    "product": product,
+                    "version_tuple": version_tuple,
+                    "run_num": run_num,
+                    "filename": filename,
+                    "product_source_network": product_source_network,
+                    "oneflux_code_version": version,
+                    "first_year": first_year,
+                    "last_year": last_year,
+                }
+
+        if latest_product is None:
+            logger.debug(
+                f"No valid production-ready products found for {site_id} (currently only beta products available)"
+            )
+            return None
+
+        logger.debug(
+            f"Selected product for {site_id}: {latest_product['filename']} "
+            f"(version: {latest_product['version_tuple']}, run: {latest_product['run_num']})"
+        )
+
+        return latest_product
+
+    async def _combine_metadata(
+        self, bif_metadata: Dict[str, Dict[str, Any]], product_metadata: Dict[str, List[Dict[str, Any]]]
+    ) -> AsyncGenerator[FluxnetDatasetMetadata, None]:
+        """
+        Combine BIF metadata and product metadata to create FluxnetDatasetMetadata objects.
+
+        This method selects the best product for each site and extracts filename metadata
+        in a single pass.
+
+        Args:
+            bif_metadata: Dictionary of site metadata from BIF file
+            product_metadata: Dictionary mapping site_id to list of available products
+
+        Yields:
+            FluxnetDatasetMetadata objects
+        """
+        # Find sites that have both BIF and product metadata
+        common_sites = set(bif_metadata.keys()) & set(product_metadata.keys())
+
+        if not common_sites:
+            logger.warning("No sites found with both BIF and product metadata")
+            return
+
+        logger.info(f"Processing {len(common_sites)} sites with complete metadata")
+
+        for site_id in common_sites:
+            try:
+                site_meta = bif_metadata[site_id]
+                products_list = product_metadata[site_id]
+
+                # Select best product and extract metadata (single extraction point!)
+                latest_product = self._select_latest_product_version(products_list, site_id)
+                if not latest_product:
+                    logger.debug(f"No valid product found for site {site_id}, skipping")
+                    continue
+
+                # Extract metadata from the selection result
+                selected_product = latest_product.get("product", {})
+                filename = latest_product.get("filename", "")
+                product_source_network = latest_product.get("product_source_network", "")
+                oneflux_code_version = latest_product.get("oneflux_code_version", "")
+                first_year = latest_product.get("first_year", 0)
+                last_year = latest_product.get("last_year", 0)
+
+                # Build BadmSiteGeneralInfo
+                team_members = []
+                for tm_data in site_meta.get("team_members", []):
+                    try:
+                        team_member = TeamMember(
+                            team_member_name=tm_data.get("name", ""),
+                            team_member_role=tm_data.get("role", ""),
+                            team_member_email=tm_data.get("email", ""),
+                        )
+                        team_members.append(team_member)
+                    except Exception as e:
+                        logger.warning(f"Error parsing team member for site {site_id}: {e}")
+                        continue
+
+                site_info = BadmSiteGeneralInfo(
+                    site_id=site_id,
+                    site_name=site_meta.get("site_name", ""),
+                    data_hub="TERN",
+                    location_lat=site_meta.get("location_lat", 0.0),
+                    location_long=site_meta.get("location_long", 0.0),
+                    igbp=site_meta.get("igbp", "UNK"),
+                    network=site_meta.get("network", []),
+                    group_team_member=team_members,
+                )
+
+                # Get citation
+                product_citation = selected_product.get("product_citation", "")
+
+                # Skip site if citation is not available
+                if not product_citation:
+                    logger.warning(f"Skipping site {site_id} - no citation available. Please contact TERN support.")
+                    continue
+
+                product_data = DataFluxnetProduct(
+                    first_year=first_year,
+                    last_year=last_year,
+                    download_link=selected_product.get("product_url", ""),
+                    product_citation=product_citation,
+                    product_id=selected_product.get("product_id", ""),
+                    oneflux_code_version=oneflux_code_version,
+                    product_source_network=product_source_network,
+                    fluxnet_product_name=filename,
+                )
+
+                metadata = FluxnetDatasetMetadata(site_info=site_info, product_data=product_data)
+
+                yield metadata
+
+            except Exception as e:
+                logger.warning(f"Error processing site {site_id}: {e}. Skipping this site.")
+                continue
+
+
+# Auto-register the plugin
+from fluxnet_shuttle.core.registry import registry
+
+registry.register(TERNPlugin)

--- a/src/fluxnet_shuttle/shuttle.py
+++ b/src/fluxnet_shuttle/shuttle.py
@@ -87,9 +87,9 @@ def _extract_filename_from_url(url: str) -> str:
     return filename
 
 
-def extract_fluxnet_filename_metadata(filename: str) -> tuple[str, str]:
+def extract_fluxnet_filename_metadata(filename: str) -> tuple[str, str, int, int, str]:
     """
-    Extract both product source network and code version from FLUXNET filename.
+    Extract product source network, code version, year range, and run from FLUXNET filename.
 
     FLUXNET filenames follow the archive format (ZIP):
        <network_id>_<site_id>_FLUXNET_<year_range>_<version>_<run>.zip
@@ -98,28 +98,32 @@ def extract_fluxnet_filename_metadata(filename: str) -> tuple[str, str]:
         filename: The filename or URL to extract metadata from
 
     Returns:
-        Tuple of (product_source_network, oneflux_code_version). Returns ("", "") if filename is invalid.
+        Tuple of (product_source_network, oneflux_code_version, first_year, last_year, run).
+        Returns ("", "", 0, 0, "") if filename is invalid.
 
     Examples:
         >>> extract_fluxnet_filename_metadata("AMF_US-Ha1_FLUXNET_1991-2020_v1.2_r2.zip")
-        ('AMF', 'v1.2')
+        ('AMF', 'v1.2', 1991, 2020, 'r2')
         >>> extract_fluxnet_filename_metadata("invalid_filename.zip")
-        ('', '')
+        ('', '', 0, 0, '')
     """
     if not filename:
-        return ("", "")
+        return ("", "", 0, 0, "")
 
     filename_only = _extract_filename_from_url(filename)
 
     # ZIP format: <network_id>_<site_id>_FLUXNET_<year_range>_<version>_<run>.zip
     zip_match = re.match(_FLUXNET_ZIP_PATTERN, filename_only, re.IGNORECASE)
     if zip_match:
-        # Extract network_id from group 1 and version from group 5
+        # Extract all metadata from capture groups
         product_source_network = zip_match.group(1)
+        first_year = int(zip_match.group(3))
+        last_year = int(zip_match.group(4))
         oneflux_code_version = zip_match.group(5)
-        return (product_source_network, oneflux_code_version)
+        run = zip_match.group(6)
+        return (product_source_network, oneflux_code_version, first_year, last_year, run)
 
-    return ("", "")
+    return ("", "", 0, 0, "")
 
 
 def validate_fluxnet_filename_format(filename: str) -> bool:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -235,9 +235,10 @@ class TestShuttleConfig:
         """Test creating default configuration."""
         config = ShuttleConfig._create_default_config()
 
-        assert config.parallel_requests == 2
+        assert config.parallel_requests == 3  # Hardcoded default
         assert "ameriflux" in config.data_hubs
         assert "icos" in config.data_hubs
+        assert "tern" in config.data_hubs
 
     def test_data_hub_config_creation(self):
         """Test creating DataHubConfig."""
@@ -250,9 +251,10 @@ class TestShuttleConfig:
         config_path = tmp_path / "nonexistent.yaml"
         config = ShuttleConfig.load_from_file(config_path)
 
-        assert config.parallel_requests == 2
+        assert config.parallel_requests == 3
         assert "ameriflux" in config.data_hubs
         assert "icos" in config.data_hubs
+        assert "tern" in config.data_hubs
 
     def test_load_from_file_invalid_yaml(self, tmp_path):
         """Test loading config from an invalid YAML file falls back to defaults."""
@@ -261,9 +263,10 @@ class TestShuttleConfig:
 
         config = ShuttleConfig.load_from_file(config_path)
 
-        assert config.parallel_requests == 2
+        assert config.parallel_requests == 3
         assert "ameriflux" in config.data_hubs
         assert "icos" in config.data_hubs
+        assert "tern" in config.data_hubs
 
     def test_load_from_file_valid_yaml(self, tmp_path):
         """Test loading config from a valid YAML file."""
@@ -276,17 +279,17 @@ class TestShuttleConfig:
                 enabled: true
               icos:
                 enabled: true
-              fluxnet2015:
-                enabled: false
+              tern:
+                enabled: true
             """
         )
 
         config = ShuttleConfig.load_from_file(config_path)
 
-        assert config.parallel_requests == 3
+        assert config.parallel_requests == 3  # Loaded from the YAML file
         assert "ameriflux" in config.data_hubs
         assert "icos" in config.data_hubs
-        assert "fluxnet2015" in config.data_hubs
+        assert "tern" in config.data_hubs
 
 
 class TestExceptions:

--- a/tests/test_plugin_tern.py
+++ b/tests/test_plugin_tern.py
@@ -1,0 +1,816 @@
+"""Test suite for fluxnet_shuttle.plugins.tern module."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from fluxnet_shuttle.core.exceptions import PluginError
+from fluxnet_shuttle.plugins import tern
+
+
+class TestBIFParser:
+    """Test cases for BIFParser."""
+
+    def test_parse_bif_content_basic(self):
+        """Test basic BIF content parsing."""
+        content = """SITE_ID,GROUP_ID,VARIABLE_GROUP,VARIABLE,DATAVALUE
+AU-Lox,6,HEADER,SITE_NAME,Loxton Eddy Covariance Site
+AU-Lox,8,IGBP,IGBP,DBF
+AU-Lox,10,LOCATION,LOCATION_LAT,-34.47035
+AU-Lox,10,LOCATION,LOCATION_LONG,140.65512"""
+
+        parser = tern.BIFParser()
+        result = parser.parse_bif_content(content)
+
+        assert "AU-Lox" in result
+        assert "AU-Lox_6" in result["AU-Lox"]
+        assert "AU-Lox_8" in result["AU-Lox"]
+        assert "AU-Lox_10" in result["AU-Lox"]
+
+        # Check HEADER group
+        assert "HEADER" in result["AU-Lox"]["AU-Lox_6"]
+        assert {"SITE_NAME": "Loxton Eddy Covariance Site"} in result["AU-Lox"]["AU-Lox_6"]["HEADER"]
+
+        # Check IGBP group
+        assert "IGBP" in result["AU-Lox"]["AU-Lox_8"]
+        assert {"IGBP": "DBF"} in result["AU-Lox"]["AU-Lox_8"]["IGBP"]
+
+        # Check LOCATION group
+        assert "LOCATION" in result["AU-Lox"]["AU-Lox_10"]
+        location_items = result["AU-Lox"]["AU-Lox_10"]["LOCATION"]
+        assert {"LOCATION_LAT": "-34.47035"} in location_items
+        assert {"LOCATION_LONG": "140.65512"} in location_items
+
+    def test_parse_bif_content_team_members(self):
+        """Test parsing team member groups."""
+        content = """SITE_ID,GROUP_ID,VARIABLE_GROUP,VARIABLE,DATAVALUE
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_NAME,Robert Stevens
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_ROLE,PI
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_EMAIL,rmstevens.water@gmail.com
+AU-Lox,17,TEAM_MEMBER,TEAM_MEMBER_NAME,Cacilia Ewenz
+AU-Lox,17,TEAM_MEMBER,TEAM_MEMBER_ROLE,Technician
+AU-Lox,17,TEAM_MEMBER,TEAM_MEMBER_EMAIL,cacilia.ewenz@internode.on.net"""
+
+        parser = tern.BIFParser()
+        result = parser.parse_bif_content(content)
+
+        # Two different GROUP_IDs for team members
+        assert "AU-Lox_16" in result["AU-Lox"]
+        assert "AU-Lox_17" in result["AU-Lox"]
+
+        # Check first team member
+        team1_items = result["AU-Lox"]["AU-Lox_16"]["TEAM_MEMBER"]
+        assert {"TEAM_MEMBER_NAME": "Robert Stevens"} in team1_items
+        assert {"TEAM_MEMBER_ROLE": "PI"} in team1_items
+        assert {"TEAM_MEMBER_EMAIL": "rmstevens.water@gmail.com"} in team1_items
+
+        # Check second team member
+        team2_items = result["AU-Lox"]["AU-Lox_17"]["TEAM_MEMBER"]
+        assert {"TEAM_MEMBER_NAME": "Cacilia Ewenz"} in team2_items
+        assert {"TEAM_MEMBER_ROLE": "Technician"} in team2_items
+
+    def test_parse_bif_content_multiple_sites(self):
+        """Test parsing BIF content with multiple sites."""
+        content = """SITE_ID,GROUP_ID,VARIABLE_GROUP,VARIABLE,DATAVALUE
+AU-Lox,6,HEADER,SITE_NAME,Loxton Site
+AU-Lox,8,IGBP,IGBP,DBF
+AU-Cow,6,HEADER,SITE_NAME,Cowombat Site
+AU-Cow,8,IGBP,IGBP,EBF"""
+
+        parser = tern.BIFParser()
+        result = parser.parse_bif_content(content)
+
+        assert "AU-Lox" in result
+        assert "AU-Cow" in result
+
+        # Check that GROUP_IDs are unique per site
+        assert "AU-Lox_6" in result["AU-Lox"]
+        assert "AU-Cow_6" in result["AU-Cow"]
+
+        # Verify site names are different
+        lox_name = result["AU-Lox"]["AU-Lox_6"]["HEADER"][0]["SITE_NAME"]
+        cow_name = result["AU-Cow"]["AU-Cow_6"]["HEADER"][0]["SITE_NAME"]
+        assert lox_name == "Loxton Site"
+        assert cow_name == "Cowombat Site"
+
+    def test_parse_bif_content_invalid_header(self):
+        """Test parsing BIF content with invalid header."""
+        content = """SITE_ID,GROUP_ID,INVALID_COLUMN,VARIABLE,DATAVALUE
+AU-Lox,6,HEADER,SITE_NAME,Loxton"""
+
+        parser = tern.BIFParser()
+        with pytest.raises(ValueError, match="Invalid BIF file format"):
+            parser.parse_bif_content(content)
+
+    def test_extract_site_metadata_complete(self):
+        """Test extracting complete site metadata."""
+        # First parse a complete BIF structure
+        content = """SITE_ID,GROUP_ID,VARIABLE_GROUP,VARIABLE,DATAVALUE
+AU-Lox,6,HEADER,SITE_NAME,Loxton Eddy Covariance Site
+AU-Lox,8,IGBP,IGBP,DBF
+AU-Lox,10,LOCATION,LOCATION_LAT,-34.47035
+AU-Lox,10,LOCATION,LOCATION_LONG,140.65512
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_NAME,Robert Stevens
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_ROLE,PI
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_EMAIL,rmstevens.water@gmail.com
+AU-Lox,19,UTC_OFFSET,UTC_OFFSET,9.5"""
+
+        parser = tern.BIFParser()
+        parsed_data = parser.parse_bif_content(content)
+        metadata = parser.extract_site_metadata("AU-Lox", parsed_data["AU-Lox"])
+
+        assert metadata["site_id"] == "AU-Lox"
+        assert metadata["site_name"] == "Loxton Eddy Covariance Site"
+        assert metadata["location_lat"] == -34.47035
+        assert metadata["location_long"] == 140.65512
+        assert metadata["igbp"] == "DBF"
+        assert metadata["utc_offset"] == 9.5
+
+        # Check team members
+        assert len(metadata["team_members"]) == 1
+        assert metadata["team_members"][0]["name"] == "Robert Stevens"
+        assert metadata["team_members"][0]["role"] == "PI"
+        assert metadata["team_members"][0]["email"] == "rmstevens.water@gmail.com"
+
+    def test_extract_site_metadata_multiple_team_members(self):
+        """Test extracting metadata with multiple team members."""
+        content = """SITE_ID,GROUP_ID,VARIABLE_GROUP,VARIABLE,DATAVALUE
+AU-Lox,6,HEADER,SITE_NAME,Loxton Site
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_NAME,Robert Stevens
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_ROLE,PI
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_EMAIL,rmstevens.water@gmail.com
+AU-Lox,17,TEAM_MEMBER,TEAM_MEMBER_NAME,Cacilia Ewenz
+AU-Lox,17,TEAM_MEMBER,TEAM_MEMBER_ROLE,Technician
+AU-Lox,17,TEAM_MEMBER,TEAM_MEMBER_EMAIL,cacilia.ewenz@internode.on.net"""
+
+        parser = tern.BIFParser()
+        parsed_data = parser.parse_bif_content(content)
+        metadata = parser.extract_site_metadata("AU-Lox", parsed_data["AU-Lox"])
+
+        assert len(metadata["team_members"]) == 2
+        assert metadata["team_members"][0]["name"] == "Robert Stevens"
+        assert metadata["team_members"][0]["role"] == "PI"
+        assert metadata["team_members"][1]["name"] == "Cacilia Ewenz"
+        assert metadata["team_members"][1]["role"] == "Technician"
+
+    def test_extract_site_metadata_invalid_coordinates(self):
+        """Test handling of invalid coordinate values."""
+        content = """SITE_ID,GROUP_ID,VARIABLE_GROUP,VARIABLE,DATAVALUE
+AU-Lox,10,LOCATION,LOCATION_LAT,invalid_lat
+AU-Lox,10,LOCATION,LOCATION_LONG,invalid_long"""
+
+        parser = tern.BIFParser()
+        parsed_data = parser.parse_bif_content(content)
+        metadata = parser.extract_site_metadata("AU-Lox", parsed_data["AU-Lox"])
+
+        # Should default to 0.0 for invalid values
+        assert metadata["location_lat"] == 0.0
+        assert metadata["location_long"] == 0.0
+
+    def test_extract_site_metadata_network_list(self):
+        """Test extracting network list."""
+        content = """SITE_ID,GROUP_ID,VARIABLE_GROUP,VARIABLE,DATAVALUE
+AU-Lox,20,NETWORK,NETWORK,TERN
+AU-Lox,21,NETWORK,NETWORK,OzFlux"""
+
+        parser = tern.BIFParser()
+        parsed_data = parser.parse_bif_content(content)
+        metadata = parser.extract_site_metadata("AU-Lox", parsed_data["AU-Lox"])
+
+        assert "TERN" in metadata["network"]
+        assert "OzFlux" in metadata["network"]
+        assert len(metadata["network"]) == 2
+
+
+class TestTERNPlugin:
+    """Test cases for TERNPlugin."""
+
+    def test_plugin_properties(self):
+        """Test TERNPlugin properties."""
+        plugin = tern.TERNPlugin()
+
+        assert plugin.name == "tern"
+        assert plugin.display_name == "TERN"
+
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_bif_metadata")
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_product_metadata")
+    def test_get_sites_success(self, mock_fetch_product, mock_fetch_bif):
+        """Test successful retrieval of sites."""
+        # Mock BIF metadata
+        mock_fetch_bif.return_value = {
+            "AU-Lox": {
+                "site_id": "AU-Lox",
+                "site_name": "Loxton Eddy Covariance Site",
+                "location_lat": -34.47035,
+                "location_long": 140.65512,
+                "igbp": "DBF",
+                "network": ["TERN"],
+                "team_members": [
+                    {
+                        "name": "Robert Stevens",
+                        "role": "PI",
+                        "email": "rmstevens.water@gmail.com",
+                    }
+                ],
+                "utc_offset": 9.5,
+            }
+        }
+
+        # Mock product metadata
+        mock_fetch_product.return_value = {
+            "AU-Lox": [
+                {
+                    "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1_r1.zip",
+                    "product_id": "doi:10.1234/tern.au-lox",
+                    "product_citation": "Stevens et al. (2020). Loxton Site FLUXNET Data.",
+                }
+            ]
+        }
+
+        plugin = tern.TERNPlugin()
+        sites = list(plugin.get_sites())
+
+        assert len(sites) == 1
+        assert sites[0].site_info.site_id == "AU-Lox"
+        assert sites[0].site_info.site_name == "Loxton Eddy Covariance Site"
+        assert sites[0].site_info.data_hub == "TERN"
+        assert sites[0].site_info.location_lat == -34.47035
+        assert sites[0].site_info.location_long == 140.65512
+        assert sites[0].site_info.igbp == "DBF"
+        assert "TERN" in sites[0].site_info.network
+        assert len(sites[0].site_info.group_team_member) == 1
+        assert sites[0].site_info.group_team_member[0].team_member_name == "Robert Stevens"
+
+        # Check product data
+        assert sites[0].product_data.product_id == "doi:10.1234/tern.au-lox"
+        assert sites[0].product_data.product_citation == "Stevens et al. (2020). Loxton Site FLUXNET Data."
+        assert sites[0].product_data.fluxnet_product_name == "TERN_AU-Lox_FLUXNET_2008-2020_v1_r1.zip"
+
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_bif_metadata")
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_product_metadata")
+    def test_get_sites_no_common_sites(self, mock_fetch_product, mock_fetch_bif):
+        """Test get_sites when BIF and product metadata have no common sites."""
+        mock_fetch_bif.return_value = {
+            "AU-Lox": {
+                "site_id": "AU-Lox",
+                "site_name": "Loxton Site",
+                "location_lat": -34.47035,
+                "location_long": 140.65512,
+                "igbp": "DBF",
+                "network": [],
+                "team_members": [],
+                "utc_offset": None,
+            }
+        }
+
+        mock_fetch_product.return_value = {
+            "AU-Cow": [
+                {  # Different site
+                    "product_url": "https://data.tern.org.au/TERN_AU-Cow_FLUXNET_2010-2020_v1_r1.zip",
+                    "product_id": "doi:10.1234/tern.au-cow",
+                    "product_citation": "Citation for AU-Cow",
+                }
+            ]
+        }
+
+        plugin = tern.TERNPlugin()
+        sites = list(plugin.get_sites())
+
+        assert len(sites) == 0
+
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_bif_metadata")
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_product_metadata")
+    def test_get_sites_invalid_filename_format(self, mock_fetch_product, mock_fetch_bif):
+        """Test get_sites skips sites with invalid filename format.
+
+        When _fetch_product_metadata is called, it internally uses _parse_and_select_products
+        which filters out invalid filenames. So if a site has only invalid filenames,
+        _fetch_product_metadata won't return an entry for that site.
+        """
+        mock_fetch_bif.return_value = {
+            "AU-Lox": {
+                "site_id": "AU-Lox",
+                "site_name": "Loxton Site",
+                "location_lat": -34.47035,
+                "location_long": 140.65512,
+                "igbp": "DBF",
+                "network": [],
+                "team_members": [],
+                "utc_offset": None,
+            }
+        }
+
+        # No products returned because all filenames were invalid
+        # (filtered out by _parse_and_select_products)
+        mock_fetch_product.return_value = {}
+
+        plugin = tern.TERNPlugin()
+        sites = list(plugin.get_sites())
+
+        # Should skip the site due to no valid products
+        assert len(sites) == 0
+
+    def test_parse_products(self):
+        """Test parsing product metadata file into lists per site."""
+        content = """SITE_ID,PRODUCT_URL,PRODUCT_ID,PRODUCT_CITATION
+AU-Lox,https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1_r1.zip,doi:10.1234/tern.au-lox,Stevens et al. (2020)
+AU-Cow,https://data.tern.org.au/TERN_AU-Cow_FLUXNET_2010-2020_v1_r1.zip,doi:10.1234/tern.au-cow,Jones et al. (2021)"""
+
+        result = tern.TERNPlugin._parse_products(content)
+
+        assert "AU-Lox" in result
+        assert "AU-Cow" in result
+
+        # Now returns lists of products
+        assert len(result["AU-Lox"]) == 1
+        assert result["AU-Lox"][0]["product_url"] == "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1_r1.zip"
+        assert result["AU-Lox"][0]["product_id"] == "doi:10.1234/tern.au-lox"
+        assert result["AU-Lox"][0]["product_citation"] == "Stevens et al. (2020)"
+
+        assert len(result["AU-Cow"]) == 1
+        assert result["AU-Cow"][0]["product_url"] == "https://data.tern.org.au/TERN_AU-Cow_FLUXNET_2010-2020_v1_r1.zip"
+        assert result["AU-Cow"][0]["product_id"] == "doi:10.1234/tern.au-cow"
+        assert result["AU-Cow"][0]["product_citation"] == "Jones et al. (2021)"
+
+    def test_select_latest_product_latest_version(self):
+        """Test selecting the latest version when multiple versions exist."""
+        products = [
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.2_r1.zip",
+                "product_id": "doi:10.1234/tern.au-lox.v1.2",
+                "product_citation": "Citation v1.2",
+            },
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.3_r1.zip",
+                "product_id": "doi:10.1234/tern.au-lox.v1.3",
+                "product_citation": "Citation v1.3",
+            },
+        ]
+
+        result = tern.TERNPlugin._select_latest_product_version(products, "AU-Lox")
+
+        assert result is not None
+        assert result["product"]["product_url"] == "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.3_r1.zip"
+        assert result["filename"] == "TERN_AU-Lox_FLUXNET_2008-2020_v1.3_r1.zip"
+        assert result["product_source_network"] == "TERN"
+        assert result["oneflux_code_version"] == "v1.3"
+        assert result["first_year"] == 2008
+        assert result["last_year"] == 2020
+
+    def test_select_latest_product_latest_run(self):
+        """Test selecting the latest run when multiple runs exist for the same version."""
+        products = [
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.3_r1.zip",
+                "product_id": "doi:10.1234/tern.au-lox.r1",
+                "product_citation": "Citation r1",
+            },
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.3_r2.zip",
+                "product_id": "doi:10.1234/tern.au-lox.r2",
+                "product_citation": "Citation r2",
+            },
+        ]
+
+        result = tern.TERNPlugin._select_latest_product_version(products, "AU-Lox")
+
+        assert result is not None
+        assert result["product"]["product_url"] == "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.3_r2.zip"
+        assert result["filename"] == "TERN_AU-Lox_FLUXNET_2008-2020_v1.3_r2.zip"
+
+    def test_select_latest_product_newer_version_first(self):
+        """Test when newer version comes before older version in the list."""
+        products = [
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.3_r1.zip",
+                "product_id": "doi:10.1234/tern.au-lox.v1.3",
+                "product_citation": "Citation v1.3",
+            },
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.2_r1.zip",
+                "product_id": "doi:10.1234/tern.au-lox.v1.2",
+                "product_citation": "Citation v1.2",
+            },
+        ]
+
+        result = tern.TERNPlugin._select_latest_product_version(products, "AU-Lox")
+
+        assert result is not None
+        assert result["product"]["product_url"] == "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.3_r1.zip"
+
+    def test_select_latest_product_major_version_comparison(self):
+        """Test comparison when major versions differ (older major version first)."""
+        products = [
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.9_r1.zip",
+                "product_id": "doi:10.1234/tern.au-lox.v1.9",
+                "product_citation": "Citation v1.9",
+            },
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v2.0_r1.zip",
+                "product_id": "doi:10.1234/tern.au-lox.v2.0",
+                "product_citation": "Citation v2.0",
+            },
+        ]
+
+        result = tern.TERNPlugin._select_latest_product_version(products, "AU-Lox")
+
+        assert result is not None
+        assert result["product"]["product_url"] == "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v2.0_r1.zip"
+        assert result["oneflux_code_version"] == "v2.0"
+
+    def test_select_latest_product_major_version_newer_first(self):
+        """Test comparison when newer major version is encountered first."""
+        products = [
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v2.0_r1.zip",
+                "product_id": "doi:10.1234/tern.au-lox.v2.0",
+                "product_citation": "Citation v2.0",
+            },
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.9_r1.zip",
+                "product_id": "doi:10.1234/tern.au-lox.v1.9",
+                "product_citation": "Citation v1.9",
+            },
+        ]
+
+        result = tern.TERNPlugin._select_latest_product_version(products, "AU-Lox")
+
+        assert result is not None
+        assert result["product"]["product_url"] == "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v2.0_r1.zip"
+        assert result["oneflux_code_version"] == "v2.0"
+
+    def test_select_latest_product_skip_beta(self):
+        """Test that beta products are skipped."""
+        products = [
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.3_rbeta.zip",
+                "product_id": "doi:10.1234/tern.au-lox.beta",
+                "product_citation": "Citation beta",
+            },
+        ]
+
+        result = tern.TERNPlugin._select_latest_product_version(products, "AU-Lox")
+
+        # Should return None since only beta product is available
+        assert result is None
+
+    def test_select_latest_product_skip_rbeta_in_filename(self):
+        """Test that products with 'rbeta' in run are skipped after version extraction."""
+        products = [
+            {
+                # This has rbeta in the extracted run field
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.3_rbeta.zip",
+                "product_id": "doi:10.1234/tern.au-lox",
+                "product_citation": "Citation",
+            },
+        ]
+
+        result = tern.TERNPlugin._select_latest_product_version(products, "AU-Lox")
+
+        # Should skip the rbeta run
+        assert result is None
+
+    def test_select_latest_product_all_error_paths(self):
+        """Test all error/warning paths in _select_latest_product_version."""
+        products = [
+            # This one has invalid version format (non-numeric)
+            # Filtered out because version does not match regex pattern
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_vABC.DEF_r1.zip",
+                "product_id": "doi:1",
+                "product_citation": "Citation 1",
+            },
+            # This one has invalid run format (non-numeric) - filtered out because version does not match regex pattern
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.3_rXYZ.zip",
+                "product_id": "doi:2",
+                "product_citation": "Citation 2",
+            },
+        ]
+
+        result = tern.TERNPlugin._select_latest_product_version(products, "AU-Lox")
+
+        # All products should be filtered out
+        assert result is None
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._session_request")
+    async def test_fetch_bif_metadata_success(self, mock_session_request):
+        """Test successful BIF metadata fetch."""
+        bif_content = """SITE_ID,GROUP_ID,VARIABLE_GROUP,VARIABLE,DATAVALUE
+AU-Lox,6,HEADER,SITE_NAME,Loxton Site
+AU-Lox,8,IGBP,IGBP,DBF
+AU-Lox,10,LOCATION,LOCATION_LAT,-34.47035
+AU-Lox,10,LOCATION,LOCATION_LONG,140.65512"""
+
+        mock_response = AsyncMock()
+        mock_response.text = AsyncMock(return_value=bif_content)
+        mock_session_request.return_value.__aenter__.return_value = mock_response
+
+        plugin = tern.TERNPlugin()
+        result = await plugin._fetch_bif_metadata()
+
+        assert "AU-Lox" in result
+        assert result["AU-Lox"]["site_name"] == "Loxton Site"
+        assert result["AU-Lox"]["igbp"] == "DBF"
+        assert result["AU-Lox"]["location_lat"] == -34.47035
+        assert result["AU-Lox"]["location_long"] == 140.65512
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._session_request")
+    async def test_fetch_product_metadata_success(self, mock_session_request):
+        """Test successful product metadata fetch."""
+        product_content = """SITE_ID,PRODUCT_URL,PRODUCT_ID,PRODUCT_CITATION
+AU-Lox,https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1_r1.zip,doi:10.1234/tern.au-lox,Citation text"""
+
+        mock_response = AsyncMock()
+        mock_response.text = AsyncMock(return_value=product_content)
+        mock_session_request.return_value.__aenter__.return_value = mock_response
+
+        plugin = tern.TERNPlugin()
+        result = await plugin._fetch_product_metadata()
+
+        assert "AU-Lox" in result
+        # Now returns a list of products
+        assert len(result["AU-Lox"]) == 1
+        assert result["AU-Lox"][0]["product_url"] == "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1_r1.zip"
+        assert result["AU-Lox"][0]["product_id"] == "doi:10.1234/tern.au-lox"
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._session_request")
+    async def test_fetch_bif_metadata_failure(self, mock_session_request):
+        """Test BIF metadata fetch failure."""
+        mock_session_request.side_effect = PluginError("tern", "Network error")
+
+        plugin = tern.TERNPlugin()
+        with pytest.raises(PluginError):
+            await plugin._fetch_bif_metadata()
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._session_request")
+    async def test_fetch_bif_metadata_generic_exception(self, mock_session_request):
+        """Test BIF metadata fetch with generic exception."""
+        mock_session_request.side_effect = ValueError("Unexpected error")
+
+        plugin = tern.TERNPlugin()
+        with pytest.raises(PluginError, match="Failed to fetch BIF metadata"):
+            await plugin._fetch_bif_metadata()
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._session_request")
+    async def test_fetch_product_metadata_generic_exception(self, mock_session_request):
+        """Test product metadata fetch with generic exception."""
+        mock_session_request.side_effect = ValueError("Unexpected error")
+
+        plugin = tern.TERNPlugin()
+        with pytest.raises(PluginError, match="Failed to fetch product metadata"):
+            await plugin._fetch_product_metadata()
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._session_request")
+    async def test_fetch_product_metadata_plugin_error(self, mock_session_request):
+        """Test product metadata fetch with PluginError (should re-raise)."""
+        mock_session_request.side_effect = PluginError("tern", "Connection failed")
+
+        plugin = tern.TERNPlugin()
+        with pytest.raises(PluginError, match="Connection failed"):
+            await plugin._fetch_product_metadata()
+
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_bif_metadata")
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_product_metadata")
+    async def test_get_sites_generic_exception(self, mock_fetch_product, mock_fetch_bif):
+        """Test get_sites with generic exception."""
+        mock_fetch_bif.side_effect = ValueError("Unexpected error")
+
+        plugin = tern.TERNPlugin()
+        with pytest.raises(PluginError, match="Failed to retrieve data"):
+            # Get the async generator and try to iterate
+            gen = plugin.get_sites.__wrapped__(plugin)
+            async for _ in gen:
+                pass
+
+    def test_extract_site_metadata_invalid_utc_offset(self):
+        """Test extracting metadata with invalid UTC offset."""
+        content = """SITE_ID,GROUP_ID,VARIABLE_GROUP,VARIABLE,DATAVALUE
+AU-Lox,19,UTC_OFFSET,UTC_OFFSET,invalid_offset"""
+
+        parser = tern.BIFParser()
+        parsed_data = parser.parse_bif_content(content)
+        metadata = parser.extract_site_metadata("AU-Lox", parsed_data["AU-Lox"])
+
+        # Should default to None for invalid values
+        assert metadata["utc_offset"] is None
+
+    def test_extract_site_metadata_team_member_within_group(self):
+        """Test extracting team member metadata where multiple fields appear in one group."""
+        content = """SITE_ID,GROUP_ID,VARIABLE_GROUP,VARIABLE,DATAVALUE
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_NAME,First Member
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_ROLE,PI
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_EMAIL,first@example.com
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_NAME,Second Member
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_ROLE,Technician
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_EMAIL,second@example.com"""
+
+        parser = tern.BIFParser()
+        parsed_data = parser.parse_bif_content(content)
+        metadata = parser.extract_site_metadata("AU-Lox", parsed_data["AU-Lox"])
+
+        # Should have two team members from the same group
+        assert len(metadata["team_members"]) == 2
+        assert metadata["team_members"][0]["name"] == "First Member"
+        assert metadata["team_members"][1]["name"] == "Second Member"
+
+    def test_select_latest_product_no_version_match(self):
+        """Test selecting product when version/run can't be extracted."""
+        products = [
+            {
+                "product_url": "https://data.tern.org.au/invalid_format.zip",
+                "product_id": "doi:10.1234/tern.au-lox",
+                "product_citation": "Citation",
+            },
+        ]
+
+        result = tern.TERNPlugin._select_latest_product_version(products, "AU-Lox")
+
+        # Should return None since version/run couldn't be extracted
+        assert result is None
+
+    def test_select_latest_product_invalid_version_format(self):
+        """Test selecting product with invalid version format."""
+        products = [
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_vABC_r1.zip",
+                "product_id": "doi:10.1234/tern.au-lox",
+                "product_citation": "Citation",
+            },
+        ]
+
+        result = tern.TERNPlugin._select_latest_product_version(products, "AU-Lox")
+
+        # Should return None due to invalid version format
+        assert result is None
+
+    def test_select_latest_product_invalid_run_format(self):
+        """Test selecting product with invalid run format."""
+        products = [
+            {
+                "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1.3_rXYZ.zip",
+                "product_id": "doi:10.1234/tern.au-lox",
+                "product_citation": "Citation",
+            },
+        ]
+
+        result = tern.TERNPlugin._select_latest_product_version(products, "AU-Lox")
+
+        # Should return None due to invalid run format
+        assert result is None
+
+    def test_parse_products_empty_site_id(self):
+        """Test parsing products with empty site_id or product_url."""
+        content = """SITE_ID,PRODUCT_URL,PRODUCT_ID,PRODUCT_CITATION
+,https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1_r1.zip,doi:10.1234/tern.au-lox,Citation
+AU-Lox,,doi:10.1234/tern.au-lox2,Citation2"""
+
+        result = tern.TERNPlugin._parse_products(content)
+
+        # Should skip rows with empty site_id or product_url
+        assert len(result) == 0
+
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_bif_metadata")
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_product_metadata")
+    def test_get_sites_invalid_team_member_data(self, mock_fetch_product, mock_fetch_bif):
+        """Test get_sites with invalid team member data that causes exception."""
+        mock_fetch_bif.return_value = {
+            "AU-Lox": {
+                "site_id": "AU-Lox",
+                "site_name": "Loxton Site",
+                "location_lat": -34.47035,
+                "location_long": 140.65512,
+                "igbp": "DBF",
+                "network": [],
+                # Invalid team member data - missing required fields
+                "team_members": [{"invalid_field": "value"}],
+                "utc_offset": None,
+            }
+        }
+
+        mock_fetch_product.return_value = {
+            "AU-Lox": [
+                {
+                    "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1_r1.zip",
+                    "product_id": "doi:10.1234/tern.au-lox",
+                    "product_citation": "Citation text",
+                }
+            ]
+        }
+
+        plugin = tern.TERNPlugin()
+        sites = list(plugin.get_sites())
+
+        # Should still yield site but skip the invalid team member
+        assert len(sites) == 1
+        assert len(sites[0].site_info.group_team_member) == 0
+
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_bif_metadata")
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_product_metadata")
+    def test_get_sites_no_citation(self, mock_fetch_product, mock_fetch_bif):
+        """Test get_sites skips sites without citation."""
+        mock_fetch_bif.return_value = {
+            "AU-Lox": {
+                "site_id": "AU-Lox",
+                "site_name": "Loxton Site",
+                "location_lat": -34.47035,
+                "location_long": 140.65512,
+                "igbp": "DBF",
+                "network": [],
+                "team_members": [],
+                "utc_offset": None,
+            }
+        }
+
+        # Product with empty citation
+        mock_fetch_product.return_value = {
+            "AU-Lox": [
+                {
+                    "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_2008-2020_v1_r1.zip",
+                    "product_id": "doi:10.1234/tern.au-lox",
+                    "product_citation": "",  # Empty citation
+                }
+            ]
+        }
+
+        plugin = tern.TERNPlugin()
+        sites = list(plugin.get_sites())
+
+        # Should skip site due to missing citation
+        assert len(sites) == 0
+
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_bif_metadata")
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_product_metadata")
+    def test_get_sites_no_year_in_filename(self, mock_fetch_product, mock_fetch_bif):
+        """Test get_sites with filename missing year range - should skip the site."""
+        mock_fetch_bif.return_value = {
+            "AU-Lox": {
+                "site_id": "AU-Lox",
+                "site_name": "Loxton Site",
+                "location_lat": -34.47035,
+                "location_long": 140.65512,
+                "igbp": "DBF",
+                "network": [],
+                "team_members": [],
+                "utc_offset": None,
+            }
+        }
+
+        # Product with filename that doesn't have year range (invalid format)
+        mock_fetch_product.return_value = {
+            "AU-Lox": [
+                {
+                    "product_url": "https://data.tern.org.au/TERN_AU-Lox_FLUXNET_NOYEAR_v1_r1.zip",
+                    "product_id": "doi:10.1234/tern.au-lox",
+                    "product_citation": "Citation text",
+                }
+            ]
+        }
+
+        plugin = tern.TERNPlugin()
+        sites = list(plugin.get_sites())
+
+        # Should skip sites with invalid year data (no year range in filename)
+        assert len(sites) == 0
+
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_bif_metadata")
+    @patch("fluxnet_shuttle.plugins.tern.TERNPlugin._fetch_product_metadata")
+    def test_get_sites_exception_during_processing(self, mock_fetch_product, mock_fetch_bif):
+        """Test get_sites handles exceptions during site processing."""
+        mock_fetch_bif.return_value = {
+            "AU-Lox": {
+                "site_id": "AU-Lox",
+                "site_name": "Loxton Site",
+                "location_lat": -34.47035,
+                "location_long": 140.65512,
+                "igbp": "DBF",
+                "network": [],
+                "team_members": [],
+                "utc_offset": None,
+            }
+        }
+
+        # Return invalid data that will cause an exception
+        mock_fetch_product.return_value = {
+            "AU-Lox": [
+                {
+                    "product_url": None,  # This will cause an error
+                    "product_id": "doi:10.1234/tern.au-lox",
+                    "product_citation": "Citation",
+                }
+            ]
+        }
+
+        plugin = tern.TERNPlugin()
+        sites = list(plugin.get_sites())
+
+        # Should skip the site and log warning
+        assert len(sites) == 0

--- a/tests/test_shuttle.py
+++ b/tests/test_shuttle.py
@@ -58,44 +58,73 @@ class TestExtractFluxnetFilenameMetadata:
     """Test cases for the extract_fluxnet_filename_metadata function (combined extraction)."""
 
     def test_valid_amf_filename(self):
-        """Test extracting both metadata from AmeriFlux filename."""
+        """Test extracting metadata from AmeriFlux filename."""
         filename = "AMF_US-Ha1_FLUXNET_2005-2012_v3_r7.zip"
-        source_network, version = extract_fluxnet_filename_metadata(filename)
+        source_network, version, first_year, last_year, run = extract_fluxnet_filename_metadata(filename)
         assert source_network == "AMF"
         assert version == "v3"
+        assert first_year == 2005
+        assert last_year == 2012
+        assert run == "r7"
 
     def test_valid_icosetc_filename(self):
-        """Test extracting both metadata from ICOS filename."""
+        """Test extracting metadata from ICOS filename."""
         filename = "ICOSETC_BE-Bra_FLUXNET_2020-2024_v1.4_r1.zip"
-        source_network, version = extract_fluxnet_filename_metadata(filename)
+        source_network, version, first_year, last_year, run = extract_fluxnet_filename_metadata(filename)
         assert source_network == "ICOSETC"
         assert version == "v1.4"
+        assert first_year == 2020
+        assert last_year == 2024
+        assert run == "r1"
 
     def test_valid_filename_with_url(self):
-        """Test extracting both metadata from full URL."""
+        """Test extracting metadata from full URL."""
         url = "https://example.com/AMF_AR-Bal_FLUXNET_2012-2013_v3_r7.zip"
-        source_network, version = extract_fluxnet_filename_metadata(url)
+        source_network, version, first_year, last_year, run = extract_fluxnet_filename_metadata(url)
         assert source_network == "AMF"
         assert version == "v3"
+        assert first_year == 2012
+        assert last_year == 2013
+        assert run == "r7"
 
     def test_invalid_filename_format(self):
         """Test with filename that doesn't match pattern."""
         filename = "invalid_filename.zip"
-        source_network, version = extract_fluxnet_filename_metadata(filename)
+        source_network, version, first_year, last_year, run = extract_fluxnet_filename_metadata(filename)
         assert source_network == ""
         assert version == ""
+        assert first_year == 0
+        assert last_year == 0
+        assert run == ""
 
     def test_empty_filename(self):
         """Test with empty filename."""
-        source_network, version = extract_fluxnet_filename_metadata("")
+        source_network, version, first_year, last_year, run = extract_fluxnet_filename_metadata("")
         assert source_network == ""
         assert version == ""
+        assert first_year == 0
+        assert last_year == 0
+        assert run == ""
 
     def test_none_filename(self):
         """Test with None filename."""
-        source_network, version = extract_fluxnet_filename_metadata(None)
+        source_network, version, first_year, last_year, run = extract_fluxnet_filename_metadata(None)
         assert source_network == ""
         assert version == ""
+        assert first_year == 0
+        assert last_year == 0
+        assert run == ""
+
+    def test_filename_with_rbeta_run_number(self):
+        """Test that filename with 'rbeta' as run number fails validation."""
+        filename = "TERN_AU-Lox_FLUXNET_2008-2020_v1.3_rbeta.zip"
+        source_network, version, first_year, last_year, run = extract_fluxnet_filename_metadata(filename)
+        # Should return empty strings because 'rbeta' doesn't match the pattern (r\d+)
+        assert source_network == ""
+        assert version == ""
+        assert first_year == 0
+        assert last_year == 0
+        assert run == ""
 
 
 class TestValidateFluxnetFilenameFormat:
@@ -128,6 +157,11 @@ class TestValidateFluxnetFilenameFormat:
     def test_partial_format(self):
         """Test filename with partial format."""
         filename = "US-Ha1_FLUXNET_2005-2012.zip"
+        assert validate_fluxnet_filename_format(filename) is False
+
+    def test_rbeta_run_number_invalid(self):
+        """Test that filename with 'rbeta' as run number is invalid."""
+        filename = "TERN_AU-Lox_FLUXNET_2008-2020_v1.3_rbeta.zip"
         assert validate_fluxnet_filename_format(filename) is False
 
 


### PR DESCRIPTION
Resolves #68 68 by implementing a production-ready TERN data hub plugin for
accessing FLUXNET data from the Terrestrial Ecosystem Research Network.

## Implementation

### Core Features
- **BIF Parser**: Parses BADM Interchange Format (BIF) CSV files for site metadata
- **Product Catalogue**: Fetches and parses TERN THREDDS catalogue for FLUXNET products
- **Version Selection**: Automatically selects latest run of most recent version
- **Metadata Integration**: Combines BIF metadata with product information

### Data Endpoints
- BIF metadata: https://dap.tern.org.au/thredds/fileServer/ecosystem_process/fluxnet/BIF_all_sites.csv
- Product catalogue: https://dap.tern.org.au/thredds/fileServer/ecosystem_process/fluxnet/TERN_THREDDS_catalogue.csv

### BIF Parser Capabilities
- Parses all BADM Site General Information fields
- Handles grouped metadata (site_id + group_id for uniqueness)
- Supports: HEADER, LOCATION, IGBP, HEIGHTC, TEAM_MEMBER, UTC_OFFSET, NETWORK
- Robust error handling for invalid coordinates and UTC offsets

### Product Selection Logic
Selection criteria (in order):
1. Skips 'rbeta' products (not production-ready)
2. Highest version number (e.g., v1.3 > v1.2)
3. Highest run number within version (e.g., r2 > r1)

### Technical Details
- Async/sync support via @async_to_sync_generator decorator
- Extracts year range from filename (format: FLUXNET_YYYY-YYYY)
- Validates product citations (skips sites without citations)
- Auto-registers with plugin registry
- Follows AmeriFlux/ICOS plugin patterns