### PR TITLE
docs: add TERN plugin to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/AMF-FLX/fluxnet-shuttle-lib/actions/workflows/python-ci.yml/badge.svg)
 
-A Python library for FLUXNET shuttle to discover and download global FLUXNET data from multiple data hubs, including AmeriFlux and ICOS.
+A Python library for FLUXNET shuttle to discover and download global FLUXNET data from multiple data hubs, including AmeriFlux, ICOS, and TERN.
 
 ## Features
 - **Data Download**: Download FLUXNET data from data hubs

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -126,6 +126,7 @@ Displays all registered data hub plugins with their display names and identifier
     #   Available FLUXNET data hub plugins:
     #       - AmeriFlux (ameriflux)
     #       - ICOS (icos)
+    #       - TERN (tern)
 
 Global Options
 --------------

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -89,7 +89,7 @@ You can also work with individual data hub plugins directly:
 
     # List all available plugins
     plugin_names = registry.list_plugins()
-    print(f"Available plugins: {plugin_names}")  # ['ameriflux', 'icos',...]
+    print(f"Available plugins: {plugin_names}")  # ['ameriflux', 'icos', 'tern']
 
     # Create a plugin instance
     ameriflux = registry.create_instance("ameriflux")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ FLUXNET Shuttle Library Documentation
 Welcome to FLUXNET Shuttle Library's documentation!
 
 FLUXNET Shuttle Library is a Python library for discovering and downloading global
-FLUXNET data from data hubs including AmeriFlux, ICOS, and TERN (coming soon!).
+FLUXNET data from data hubs including AmeriFlux, ICOS, and TERN.
 
 The data hubs provide FLUXNET data organized and coordinated by many regional networks, including
 AmeriFlux, AsiaFlux, ChinaFlux, JapanFlux, KoFlux, ICOS, European Flux database, OzFlux, TERN, and SAEON.
@@ -12,7 +12,7 @@ AmeriFlux, AsiaFlux, ChinaFlux, JapanFlux, KoFlux, ICOS, European Flux database,
 Features
 --------
 
-- **Data Download**: Download FLUXNET data from AmeriFlux and ICOS data hubs
+- **Data Download**: Download FLUXNET data from AmeriFlux, ICOS, and TERN data hubs
 - **Metadata Snapshot**: List metadata for FLUXNET data available via the data hubs
 - **Command Line Interface**: Easy-to-use CLI tool ``fluxnet-shuttle`` for common operations
 - **Comprehensive Logging**: Configurable logging with multiple outputs


### PR DESCRIPTION
Update README and documentation files to include TERN as a fully integrated data hub plugin alongside AmeriFlux and ICOS. This reflects the completion of TERN plugin implementation.

Changes:
- Update README.md to list TERN in supported data hubs
- Update docs/index.rst to include TERN (remove "coming soon" note)
- Update docs/developer_guide.rst with TERN in plugin examples
- Update docs/cli.rst to show TERN in listdatahubs output

Closes: #75 partially