### PR TITLE
docs: fix errors in docs and update site ids used in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fluxnet-shuttle --verbose listall
 Download data for specific sites:
 ```bash
 # Download specific sites
-fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv -s IT-Niv PE-QFR US-NGB
+fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv -s IT-Niv NZ-ADd
 
 # Download ALL sites from snapshot (prompts for confirmation)
 fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv
@@ -78,8 +78,8 @@ fluxnet-shuttle --verbose listall
 
 # Step 2: Download specific sites
 fluxnet-shuttle --verbose download \
-  -r fluxnet_shuttle_snapshot__20251006T155754.csv \
-  -s PE-QFR IT-Niv \
+  -f fluxnet_shuttle_snapshot__20251006T155754.csv \
+  -s NZ-ADd IT-Niv \
 
 ```
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -93,10 +93,10 @@ Download FLUXNET data products (zip files) for specified sites using a snapshot 
 .. code-block:: bash
 
     # Download specific sites
-    fluxnet-shuttle download -f fluxnet_shuttle_snapshot_20251114T113216.csv -s US-Ha1 US-MMS
+    fluxnet-shuttle download -f fluxnet_shuttle_snapshot_20251114T113216.csv -s KE-Kpt KR-TwB AU-Lox
 
     # Download to specific directory (directory must exist)
-    fluxnet-shuttle download -f fluxnet_shuttle_snapshot_20251114T113216.csv -s PE-QFR IT-Niv -o /data/fluxnet
+    fluxnet-shuttle download -f fluxnet_shuttle_snapshot_20251114T113216.csv -s NZ-ADd IT-Niv -o /data/fluxnet
 
     # Download ALL sites (with confirmation prompt)
     fluxnet-shuttle download -f fluxnet_shuttle_snapshot_20251114T113216.csv
@@ -161,7 +161,7 @@ Complete workflow from discovery to download:
     # Step 5: Download specific sites
     fluxnet-shuttle --verbose download \
       -f /data/snapshots/fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv \
-      -s US-ARc IT-Niv DE-Tha \
+      -s NZ-ADd IT-Niv DE-Tha \
       -o /data/fluxnet
 
     # Alternative: Download all sites (with confirmation)

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -135,7 +135,7 @@ For normal Python scripts and synchronous contexts, use regular for loops:
 
     # Sync interface - works everywhere
     for site in shuttle.get_all_sites():
-        print(f"Site: {site.site_id}")
+        print(f"Site: {site.site_info.site_id}")
 
 Asynchronous Interface
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,12 +57,12 @@ Quick Start
     print(f"Available data saved to: {csv_filename}")
 
     # Download specific sites
-    sites = ['PE-QFR', 'IT-Niv']
+    sites = ['NZ-ADd', 'IT-Niv']
     downloaded_files = download(site_ids=sites, snapshot_file=csv_filename)
 
     # Download specific sites with optional user information
     # Intended Use options: 1. Synthesis, 2. Model, 3. Remote sensing, 4. Other research, 5. Education, 6. Other
-    sites = ['PE-QFR', 'IT-Niv']
+    sites = ['NZ-ADd', 'IT-Niv']
     user_info={'ameriflux': {'user_name': 'O2. Carbon', 'user_email': 'o2.carbon@flux.flux', 'intended_use': 1, 'description': 'Analysis of water flux'}}
     downloaded_files = download(site_ids=sites, snapshot_file=csv_filename, user_info=user_info)
 
@@ -76,11 +76,11 @@ For advanced usage with error handling and the developer API, see :doc:`develope
     fluxnet-shuttle listall
 
     # Download data for specific sites using snapshot file
-    fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv -s US-Ha1 US-MMS
+    fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv -s KE-Kpt KR-TwB AU-Lox
 
     # Create output directory
     mkdir /data/fluxnet
-    fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv -s PE-QFR IT-Niv -o /data/fluxnet
+    fluxnet-shuttle download -f fluxnet_shuttle_snapshot_YYYYMMDDTHHMMSS.csv -s NZ-ADd IT-Niv -o /data/fluxnet
 
 For complete CLI documentation, see :doc:`cli`.
 

--- a/src/fluxnet_shuttle/models.py
+++ b/src/fluxnet_shuttle/models.py
@@ -55,7 +55,8 @@ Example:
     ...     product_id="10.17190/AMF/1871137",
     ...     product_citation="J. William Munger (2025), AmeriFlux FLUXNET citation ...",
     ...     product_source_network="AMF",
-    ...     oneflux_code_version="1.3"
+    ...     oneflux_code_version="1.3",
+    ...     fluxnet_product_name="AMF_US-Ha1_FLUXNET_..."
     ... )
     >>> metadata = FluxnetDatasetMetadata(
     ...     site_info=site_info,


### PR DESCRIPTION
Issue #93
Closes #92
Closes #91
Closes #89

Use only ICOS and TERN site ids in examples
Fix incorrect cli download flag in readme
Fix data model returned by get_all_sites in developer_guide example 
Add missing metadata field in models documentation