### PR TITLE
Forces output of snapshot file to use utf-8 encoding

### DIFF
--- a/src/fluxnet_shuttle/shuttle.py
+++ b/src/fluxnet_shuttle/shuttle.py
@@ -390,7 +390,7 @@ async def _write_snapshot_file(shuttle: FluxnetShuttle, fields: List[str], csv_f
     counts: Dict[str, int] = {}
     # map expansion for data hub counts
     # Write to CSV file, using asyncio file operations
-    async with aiofiles.open(csv_filename, "w") as csvfile:
+    async with aiofiles.open(csv_filename, "w", encoding="utf-8") as csvfile:
         csv_writer = csv.DictWriter(csvfile, fieldnames=fields)
         await csv_writer.writeheader()
         async for site in shuttle.get_all_sites():


### PR DESCRIPTION
Closes #97

Ensures snapshot file is always encoded in UTF-8, especially on Windows environments