### PR TITLE
refactor(core): orchestrate download functions through core shuttle

### DIFF
--- a/src/fluxnet_shuttle/core/base.py
+++ b/src/fluxnet_shuttle/core/base.py
@@ -167,15 +167,14 @@ class DataHubPlugin(ABC):
         """
         pass
 
-    @asynccontextmanager
     async def download_file(
         self,
         site_id: str,
         download_link: str,
         **kwargs: Any,
-    ) -> AsyncGenerator[aiohttp.StreamReader, None]:
+    ) -> AsyncGenerator[bytes, None]:
         """
-        Download a file from the data hub and return the content stream reader.
+        Download a file from the data hub and yield byte chunks.
 
         This method provides a default implementation that performs a simple GET request.
         Plugins can override this method to implement custom download logic, such as
@@ -187,20 +186,14 @@ class DataHubPlugin(ABC):
             **kwargs: Additional plugin-specific parameters (e.g., filename, user_name, user_email for tracking)
 
         Yields:
-            aiohttp.StreamReader: Content stream reader to read file data from
+            bytes: Byte chunks from the downloaded content
 
         Raises:
             PluginError: If download fails
-
-        Example:
-            >>> plugin = SomeDataHubPlugin()
-            >>> async with plugin.download_file("US-Ha1", "https://...", filename="file.zip") as stream:
-            ...     async for chunk in stream.iter_chunked(8192):
-            ...         process(chunk)
         """
-        # Default implementation: simple GET request
         async with self._session_request("GET", download_link) as response:
-            yield response.content
+            async for chunk in response.content.iter_any():
+                yield chunk
 
     @asynccontextmanager
     async def _session_request(

--- a/src/fluxnet_shuttle/core/shuttle.py
+++ b/src/fluxnet_shuttle/core/shuttle.py
@@ -71,10 +71,23 @@ class FluxnetShuttle:
         Yields:
             FluxnetDatasetMetadata: Site metadata objects from all data hubs
 
-        Example:
+        Examples:
+            Synchronous usage (simple):
+
+            >>> from fluxnet_shuttle.core.shuttle import FluxnetShuttle
             >>> shuttle = FluxnetShuttle()
-            >>> async for site in shuttle.get_all_sites():
+            >>> for site in shuttle.get_all_sites():
             ...     print(f"{site.site_info.site_id} from {site.site_info.data_hub}")
+
+            Asynchronous usage (when in async context):
+
+            >>> from fluxnet_shuttle.core.shuttle import FluxnetShuttle
+            >>> import asyncio
+            >>> async def list_sites():
+            ...     shuttle = FluxnetShuttle()
+            ...     async for site in shuttle.get_all_sites():
+            ...         print(f"{site.site_info.site_id} from {site.site_info.data_hub}")
+            >>> asyncio.run(list_sites())
         """
         plugins = self._get_enabled_plugins()
 
@@ -95,6 +108,87 @@ class FluxnetShuttle:
             # Log summary after iteration completes
             summary = error_collector.get_error_summary()
             logger.info(f"Completed get_all_sites: {summary.total_results} results, " f"{summary.total_errors} errors")
+
+    @async_to_sync_generator
+    async def download_dataset(
+        self,
+        site_id: str,
+        data_hub: str,
+        download_link: str,
+        **kwargs: Any,
+    ) -> AsyncGenerator[bytes, None]:
+        """
+        Download dataset as a stream of byte chunks from specified data hub.
+
+        This method delegates to the appropriate plugin's download_file method
+        through the orchestrator pattern, providing consistent error handling
+        and plugin management.
+
+        Args:
+            site_id: Site identifier
+            data_hub: Data hub name (e.g., "ameriflux", "icos")
+            download_link: URL to download from
+            **kwargs: Additional parameters passed to plugin's download_file method
+
+        Yields:
+            bytes: Byte chunks for the dataset
+
+        Examples:
+            Synchronous usage (simple):
+
+            >>> from fluxnet_shuttle.core.shuttle import FluxnetShuttle
+            >>> shuttle = FluxnetShuttle()
+            >>> with open("download.zip", "wb") as file:
+            ...     for chunk in shuttle.download_dataset(
+            ...         "ZA-Uby",
+            ...         "icos",
+            ...         "https://...",
+            ...     ):
+            ...         file.write(chunk)
+
+            Asynchronous usage (when in async context):
+
+            >>> from fluxnet_shuttle.core.shuttle import FluxnetShuttle
+            >>> import asyncio
+            >>> async def download():
+            ...     shuttle = FluxnetShuttle()
+            ...     with open("download.zip", "wb") as file:
+            ...         async for chunk in shuttle.download_dataset(
+            ...             "ZA-Uby",
+            ...             "icos",
+            ...             "https://...",
+            ...         ):
+            ...             file.write(chunk)
+            >>> asyncio.run(download())
+        """
+        download_link = str(download_link)
+        try:
+            plugin = self._get_plugin_instance(data_hub.lower())
+        except ValueError as e:
+            logger.error(f"Failed to get plugin for data hub '{data_hub}': {e}")
+            # Re-raise to maintain the expected error behavior
+            raise
+
+        error_collector = ErrorCollectingIterator(
+            {plugin.name: plugin}, "download_file", site_id=site_id, download_link=download_link, **kwargs
+        )
+        self._last_error_collector = error_collector
+        try:
+            # Check if plugin has download_file method
+            if not hasattr(plugin, "download_file"):
+                raise AttributeError(f"Plugin '{plugin.name}' does not have 'download_file' method")
+
+            # Call the plugin's download_file method and yield byte chunks
+            async for chunk in plugin.download_file(site_id=site_id, download_link=download_link, **kwargs):
+                yield chunk
+        except Exception as e:
+            logger.error(f"Failed to download dataset for site {site_id} from {data_hub}: {e}")
+            error_collector.add_error(plugin.name, e, "download_file")
+            # Re-raise to let caller handle the error
+            raise
+        finally:
+            summary = error_collector.get_error_summary()
+            logger.info(f"Completed download_dataset: {summary.total_results} results, {summary.total_errors} errors")
 
     def get_errors(self) -> ErrorSummary:
         """

--- a/src/fluxnet_shuttle/plugins/ameriflux.py
+++ b/src/fluxnet_shuttle/plugins/ameriflux.py
@@ -14,7 +14,6 @@ AmeriFlux data hub implementation for the FLUXNET Shuttle plugin system.
 
 import asyncio
 import logging
-from contextlib import asynccontextmanager
 from enum import Enum
 from http import HTTPStatus
 from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, cast
@@ -414,13 +413,12 @@ class AmeriFluxPlugin(DataHubPlugin):
                 logger.warning(f"Error parsing site data for {site_id}: {e}. Skipping this site.")
                 continue
 
-    @asynccontextmanager
     async def download_file(
         self,
         site_id: str,
         download_link: str,
         **kwargs: Any,
-    ) -> AsyncGenerator[aiohttp.StreamReader, None]:
+    ) -> AsyncGenerator[bytes, None]:
         """
         Download a file from AmeriFlux with optional user tracking.
 
@@ -439,7 +437,7 @@ class AmeriFluxPlugin(DataHubPlugin):
                   Example: {"ameriflux": {"user_name": "...", "user_email": "...", ...}}
 
         Yields:
-            aiohttp.StreamReader: Content stream reader
+            bytes: Byte chunks from the downloaded content
         """
         # Extract AmeriFlux-specific user info from kwargs
         user_info = kwargs.get("user_info", {})
@@ -468,8 +466,8 @@ class AmeriFluxPlugin(DataHubPlugin):
                 logger.warning(f"Failed to log download request for {site_id}: {e}")
 
         # Call parent class implementation to perform the actual download
-        async with super().download_file(site_id, download_link, **kwargs) as stream:
-            yield stream
+        async for chunk in super().download_file(site_id, download_link, **kwargs):
+            yield chunk
 
     async def _log_download_request(
         self,

--- a/src/fluxnet_shuttle/shuttle.py
+++ b/src/fluxnet_shuttle/shuttle.py
@@ -44,6 +44,7 @@ Metadata fields:
 
 """
 
+import asyncio
 import csv
 import logging
 import os
@@ -57,7 +58,6 @@ import aiofiles
 
 from fluxnet_shuttle import FLUXNETShuttleError
 from fluxnet_shuttle.core.decorators import async_to_sync
-from fluxnet_shuttle.core.registry import registry
 from fluxnet_shuttle.core.shuttle import FluxnetShuttle
 
 _log = logging.getLogger(__name__)
@@ -170,11 +170,11 @@ async def _download_dataset(
     **kwargs: Any,
 ) -> str:
     """
-    Download a FLUXNET dataset for a specific site using plugin's download_stream method.
+    Download a FLUXNET dataset for a specific site using the shuttle orchestrator.
 
-    This function delegates to the appropriate plugin's download_stream method,
-    which handles data hub-specific logic (e.g., AmeriFlux user info logging).
-    The shuttle orchestrator receives only the content stream, then handles file I/O using the
+    This function delegates to the shuttle orchestrator's download_dataset method,
+    which handles plugin selection and error collection. The function receives
+    byte chunks from the orchestrator and handles file I/O using the
     filename from the snapshot metadata.
 
     :param site_id: Site identifier
@@ -189,7 +189,7 @@ async def _download_dataset(
     :type output_dir: str
     :param kwargs: Additional keyword arguments.
         - user_info: Dictionary with plugin-specific user tracking info (e.g., {"ameriflux": {...}})
-        Other kwargs are passed through to the plugin's download_stream method.
+        Other kwargs are passed through to the plugin's download_file method.
     :return: The filepath where the file was saved
     :rtype: str
     :raises FLUXNETShuttleError: If download fails
@@ -197,39 +197,34 @@ async def _download_dataset(
     _log.info(f"{data_hub}: downloading site {site_id} data file: {filename}")
 
     try:
-        # Get plugin instance
-        plugin_class = registry.get_plugin(data_hub.lower())
-        if not plugin_class:
-            msg = f"Data hub plugin {data_hub} not found for site {site_id}"
-            _log.error(msg)
-            raise FLUXNETShuttleError(msg)
+        # Create shuttle instance to handle plugin orchestration
+        shuttle = FluxnetShuttle()
 
-        plugin_instance = plugin_class()
-
-        # Add filename to kwargs and pass everything to the plugin
+        # Add filename to kwargs and pass everything to the orchestrator
         kwargs["filename"] = filename
 
-        # Use plugin's download_file method to get the content stream
-        async with plugin_instance.download_file(site_id=site_id, download_link=download_link, **kwargs) as stream:
-            # Join with output directory
-            filepath = os.path.join(output_dir, filename)
+        # Get byte chunks from orchestrator, which handles plugin selection and error collection
+        filepath = os.path.join(output_dir, filename)
 
-            # Warn if file already exists and will be overwritten
-            if os.path.exists(filepath):
-                _log.warning(f"{data_hub}: file already exists and will be overwritten: {filepath}")
+        # Warn if file already exists and will be overwritten
+        if os.path.exists(filepath):
+            _log.warning(f"{data_hub}: file already exists and will be overwritten: {filepath}")
 
-            # Write the stream to file
-            with open(filepath, "wb") as file:
-                async for chunk in stream.iter_chunked(8192):
-                    file.write(chunk)
+        # Write the stream to file
+        with open(filepath, "wb") as file:
+            async for chunk in shuttle.download_dataset(
+                site_id=site_id, data_hub=data_hub.lower(), download_link=download_link, **kwargs
+            ):
+                file.write(chunk)
 
-            _log.info(f"{data_hub}: file downloaded successfully to {filepath}")
-            return filepath
+        _log.info(f"{data_hub}: file downloaded successfully to {filepath}")
+        return filepath
 
     except Exception as e:
         msg = f"Failed to download {data_hub} file for site {site_id}: {e}"
         _log.error(msg)
         raise FLUXNETShuttleError(msg) from e
+    return ""  # Should not reach here #pragma: no cover
 
 
 @async_to_sync
@@ -241,6 +236,8 @@ async def download(
 ) -> List[str]:
     """
     Download FLUXNET data for specified sites using configuration from a snapshot file.
+
+    Downloads are performed concurrently.
 
     :param site_ids: List of site IDs to download data for. If None or empty, downloads all sites from snapshot file.
     :type site_ids: Optional[List[str]]
@@ -291,8 +288,8 @@ async def download(
             raise FLUXNETShuttleError(msg)
     _log.debug("All site IDs found in snapshot file")
 
-    # Download data for each site
-    downloaded_filenames = []
+    # Build download jobs (skip sites without filenames)
+    download_jobs = []
     for site_id in site_ids:
         site = sites[site_id]
         data_hub = site["data_hub"]
@@ -304,16 +301,31 @@ async def download(
             continue
 
         _log.info(f"Downloading data for site {site_id} from data hub {data_hub}")
+        download_jobs.append(
+            {
+                "site_id": site_id,
+                "data_hub": data_hub,
+                "filename": filename,
+                "download_link": download_link,
+            }
+        )
 
-        actual_filename = await _download_dataset(
-            site_id=site_id,
-            data_hub=data_hub,
-            filename=filename,
-            download_link=download_link,
+    if not download_jobs:
+        _log.info("No valid downloads found after processing snapshot file.")
+        return []
+
+    tasks = [
+        _download_dataset(
+            site_id=job["site_id"],
+            data_hub=job["data_hub"],
+            filename=job["filename"],
+            download_link=job["download_link"],
             output_dir=output_dir,
             **kwargs,
         )
-        downloaded_filenames.append(actual_filename)
+        for job in download_jobs
+    ]
+    downloaded_filenames = await asyncio.gather(*tasks)
     _log.info(f"Downloaded data for {len(site_ids)} sites: {site_ids}")
     return downloaded_filenames
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -216,13 +216,20 @@ class TestDataHubPlugin:
 
         # Mock the response with content
         mock_response = AsyncMock()
-        mock_response.content = b"test file content"
+
+        class DummyContent:
+            async def iter_any(self):
+                yield b"test file content"
+
+        mock_response.content = DummyContent()
         mock_session_request.return_value.__aenter__.return_value = mock_response
         mock_session_request.return_value.__aexit__.return_value = None
 
         # Test the default download_stream implementation
-        async with plugin.download_file("US-TEST", download_link, filename="test.zip") as content:
-            assert content == b"test file content"
+        chunks = []
+        async for chunk in plugin.download_file("US-TEST", download_link, filename="test.zip"):
+            chunks.append(chunk)
+        assert chunks == [b"test file content"]
 
         # Verify GET request was made to download link
         mock_session_request.assert_called_once_with("GET", download_link)
@@ -271,8 +278,7 @@ class TestShuttleConfig:
     def test_load_from_file_valid_yaml(self, tmp_path):
         """Test loading config from a valid YAML file."""
         config_path = tmp_path / "valid.yaml"
-        config_path.write_text(
-            """
+        config_path.write_text("""
             parallel_requests: 3
             data_hubs:
               ameriflux:
@@ -281,8 +287,7 @@ class TestShuttleConfig:
                 enabled: true
               tern:
                 enabled: true
-            """
-        )
+            """)
 
         config = ShuttleConfig.load_from_file(config_path)
 

--- a/tests/test_plugin_ameriflux.py
+++ b/tests/test_plugin_ameriflux.py
@@ -857,12 +857,18 @@ class TestAmeriFluxPlugin:
 
         # Mock the download response
         mock_response = AsyncMock()
-        mock_response.content = b"test content"
+
+        class DummyContent:
+            async def iter_any(self):
+                yield b"test content"
+
+        mock_response.content = DummyContent()
         mock_session_request.return_value.__aenter__.return_value = mock_response
         mock_session_request.return_value.__aexit__.return_value = None
 
         # Call download_file with user_info structure
-        async with plugin.download_file(
+        chunks = []
+        async for chunk in plugin.download_file(
             site_id="US-Ha1",
             download_link="https://example.com/file.zip",
             filename="test.zip",
@@ -874,8 +880,9 @@ class TestAmeriFluxPlugin:
                     "description": "Test download",
                 }
             },
-        ) as content:
-            assert content == b"test content"
+        ):
+            chunks.append(chunk)
+        assert chunks == [b"test content"]
 
         # Verify logging was called with correct parameters
         mock_log_download.assert_called_once_with(
@@ -898,13 +905,19 @@ class TestAmeriFluxPlugin:
 
         # Mock the download response
         mock_response = AsyncMock()
-        mock_response.content = b"test content"
+
+        class DummyContent:
+            async def iter_any(self):
+                yield b"test content"
+
+        mock_response.content = DummyContent()
         mock_session_request.return_value.__aenter__.return_value = mock_response
         mock_session_request.return_value.__aexit__.return_value = None
 
         # Download should still work even if logging fails
         with caplog.at_level("WARNING", logger="fluxnet_shuttle.plugins.ameriflux"):
-            async with plugin.download_file(
+            chunks = []
+            async for chunk in plugin.download_file(
                 site_id="US-Ha1",
                 download_link="https://example.com/file.zip",
                 filename="test.zip",
@@ -914,8 +927,9 @@ class TestAmeriFluxPlugin:
                         "user_email": "test@example.com",
                     }
                 },
-            ) as content:
-                assert content == b"test content"
+            ):
+                chunks.append(chunk)
+            assert chunks == [b"test content"]
 
         # Should log warning about failed tracking
         assert "Failed to log download request for US-Ha1" in caplog.text
@@ -928,15 +942,22 @@ class TestAmeriFluxPlugin:
 
         # Mock the download response
         mock_response = AsyncMock()
-        mock_response.content = b"test content"
+
+        class DummyContent:
+            async def iter_any(self):
+                yield b"test content"
+
+        mock_response.content = DummyContent()
         mock_session_request.return_value.__aenter__.return_value = mock_response
         mock_session_request.return_value.__aexit__.return_value = None
 
         # Call without user tracking - should not attempt logging
-        async with plugin.download_file(
+        chunks = []
+        async for chunk in plugin.download_file(
             site_id="US-Ha1", download_link="https://example.com/file.zip", filename="test.zip"
-        ) as content:
-            assert content == b"test content"
+        ):
+            chunks.append(chunk)
+        assert chunks == [b"test content"]
 
 
 class TestIntendedUse:

--- a/tests/test_shuttle.py
+++ b/tests/test_shuttle.py
@@ -171,25 +171,16 @@ class TestDownloadDataset:
     @pytest.mark.asyncio
     async def test_successful_download_ameriflux(self):
         """Test successful file download for AmeriFlux."""
-        from unittest.mock import AsyncMock
-
         from fluxnet_shuttle.plugins.ameriflux import AmeriFluxPlugin
 
-        async def mock_iter_chunked(size):
+        async def mock_download_file(*_args, **_kwargs):
             for chunk in [b"chunk1", b"chunk2"]:
                 yield chunk
 
         with (
-            patch.object(AmeriFluxPlugin, "download_file") as mock_download_file,
+            patch.object(AmeriFluxPlugin, "download_file", side_effect=mock_download_file) as mock_download_file,
             patch("builtins.open", mock_open()),
         ):
-            # Create async mock stream
-            mock_stream = AsyncMock()
-            mock_stream.iter_chunked = mock_iter_chunked
-
-            # Mock async context manager to return just the stream
-            mock_download_file.return_value.__aenter__.return_value = mock_stream
-
             result = await _download_dataset("US-TEST", "AmeriFlux", "test.zip", "http://example.com/test.zip")
 
             assert result == "./test.zip"
@@ -197,25 +188,16 @@ class TestDownloadDataset:
     @pytest.mark.asyncio
     async def test_successful_download_icos(self):
         """Test successful file download for ICOS."""
-        from unittest.mock import AsyncMock
-
         from fluxnet_shuttle.plugins.icos import ICOSPlugin
 
-        async def mock_iter_chunked(size):
+        async def mock_download_file(*_args, **_kwargs):
             for chunk in [b"chunk1", b"chunk2"]:
                 yield chunk
 
         with (
-            patch.object(ICOSPlugin, "download_file") as mock_download_file,
+            patch.object(ICOSPlugin, "download_file", side_effect=mock_download_file) as mock_download_file,
             patch("builtins.open", mock_open()),
         ):
-            # Create async mock stream
-            mock_stream = AsyncMock()
-            mock_stream.iter_chunked = mock_iter_chunked
-
-            # Mock async context manager to return (stream, filename) tuple
-            mock_download_file.return_value.__aenter__.return_value = mock_stream
-
             # ICOS plugin provides ready-to-use URL with license acceptance
             result = await _download_dataset(
                 "FI-HYY", "ICOS", "test.zip", "https://data.icos-cp.eu/licence_accept?ids=%5B%22test%22%5D"
@@ -226,25 +208,16 @@ class TestDownloadDataset:
     @pytest.mark.asyncio
     async def test_successful_download_with_content_disposition(self):
         """Test that ICOS validates filename from Content-Disposition header but uses metadata filename."""
-        from unittest.mock import AsyncMock
-
         from fluxnet_shuttle.plugins.icos import ICOSPlugin
 
-        async def mock_iter_chunked(size):
+        async def mock_download_file(*_args, **_kwargs):
             for chunk in [b"chunk1", b"chunk2"]:
                 yield chunk
 
         with (
-            patch.object(ICOSPlugin, "download_file") as mock_download_file,
+            patch.object(ICOSPlugin, "download_file", side_effect=mock_download_file) as mock_download_file,
             patch("builtins.open", mock_open()),
         ):
-            # Create async mock stream
-            mock_stream = AsyncMock()
-            mock_stream.iter_chunked = mock_iter_chunked
-
-            # ICOS plugin validates filename from header but returns just the stream
-            mock_download_file.return_value.__aenter__.return_value = mock_stream
-
             result = await _download_dataset("FI-HYY", "ICOS", "metadata_file.zip", "http://example.com/download")
 
             # Should use filename from metadata (the one passed as argument)
@@ -258,7 +231,7 @@ class TestDownloadDataset:
 
         with patch.object(AmeriFluxPlugin, "download_file") as mock_download_file:
             # Simulate 404 error by raising PluginError
-            mock_download_file.return_value.__aenter__.side_effect = PluginError("ameriflux", "HTTP 404 Not Found")
+            mock_download_file.side_effect = PluginError("ameriflux", "HTTP 404 Not Found")
 
             with pytest.raises(FLUXNETShuttleError, match="Failed to download"):
                 await _download_dataset("US-TEST", "AmeriFlux", "test.zip", "http://example.com/test.zip")
@@ -271,9 +244,7 @@ class TestDownloadDataset:
 
         with patch.object(ICOSPlugin, "download_file") as mock_download_file:
             # Simulate 500 error by raising PluginError
-            mock_download_file.return_value.__aenter__.side_effect = PluginError(
-                "icos", "HTTP 500 Internal Server Error"
-            )
+            mock_download_file.side_effect = PluginError("icos", "HTTP 500 Internal Server Error")
 
             with pytest.raises(FLUXNETShuttleError, match="Failed to download"):
                 await _download_dataset("FI-HYY", "ICOS", "test.zip", "http://example.com/test.zip")
@@ -281,27 +252,18 @@ class TestDownloadDataset:
     @pytest.mark.asyncio
     async def test_file_writing(self):
         """Test that file is written correctly."""
-        from unittest.mock import AsyncMock
-
         from fluxnet_shuttle.plugins.ameriflux import AmeriFluxPlugin
 
         test_chunks = [b"data_chunk_1", b"data_chunk_2"]
 
-        async def mock_iter_chunked(size):
+        async def mock_download_file(*_args, **_kwargs):
             for chunk in test_chunks:
                 yield chunk
 
         with (
-            patch.object(AmeriFluxPlugin, "download_file") as mock_download_file,
+            patch.object(AmeriFluxPlugin, "download_file", side_effect=mock_download_file) as mock_download_file,
             patch("builtins.open", mock_open()) as mock_file,
         ):
-            # Create async mock stream
-            mock_stream = AsyncMock()
-            mock_stream.iter_chunked = mock_iter_chunked
-
-            # Mock async context manager to return (stream, filename) tuple
-            mock_download_file.return_value.__aenter__.return_value = mock_stream
-
             await _download_dataset("US-TEST", "AmeriFlux", "output.zip", "http://example.com/file.zip")
 
             # Verify file was opened for writing
@@ -317,7 +279,7 @@ class TestDownloadDataset:
 
         with patch.object(AmeriFluxPlugin, "download_file") as mock_download_file:
             # Simulate network error
-            mock_download_file.return_value.__aenter__.side_effect = Exception("Network error")
+            mock_download_file.side_effect = Exception("Network error")
 
             with pytest.raises(FLUXNETShuttleError, match="Failed to download"):
                 await _download_dataset("US-TEST", "AmeriFlux", "test.zip", "http://example.com/test.zip")
@@ -326,28 +288,20 @@ class TestDownloadDataset:
     async def test_file_overwrite_warning(self):
         """Test that a warning is logged when overwriting an existing file."""
         import tempfile
-        from unittest.mock import AsyncMock
 
         from fluxnet_shuttle.plugins.ameriflux import AmeriFluxPlugin
 
-        async def mock_iter_chunked(size):
+        async def mock_download_file(*_args, **_kwargs):
             yield b"new content"
 
         with (
-            patch.object(AmeriFluxPlugin, "download_file") as mock_download_file,
+            patch.object(AmeriFluxPlugin, "download_file", side_effect=mock_download_file) as mock_download_file,
             tempfile.TemporaryDirectory() as tmpdir,
         ):
             # Create an existing file
             existing_file = os.path.join(tmpdir, "existing.zip")
             with open(existing_file, "w") as f:
                 f.write("old content")
-
-            # Mock successful download
-            mock_stream = AsyncMock()
-            mock_stream.iter_chunked = mock_iter_chunked
-
-            # Mock async context manager to return (stream, filename) tuple
-            mock_download_file.return_value.__aenter__.return_value = mock_stream
 
             # Download to the same location
             with patch("fluxnet_shuttle.shuttle._log") as mock_log:
@@ -369,29 +323,25 @@ class TestDownloadDataset:
 
         # Mock registry to return None for unknown plugin
         with patch.object(registry, "get_plugin", return_value=None):
-            with pytest.raises(FLUXNETShuttleError, match="Data hub plugin UnknownHub not found for site US-TEST"):
+            with pytest.raises(
+                FLUXNETShuttleError,
+                match="Failed to download UnknownHub file for site US-TEST.*Data hub 'unknownhub' not configured",
+            ):
                 await _download_dataset("US-TEST", "UnknownHub", "test.zip", "http://example.com/test.zip")
 
     @pytest.mark.asyncio
     async def test_download_with_user_info_kwargs(self):
         """Test _download_dataset passes plugin-specific user_info to download_file."""
-        from unittest.mock import AsyncMock
-
         from fluxnet_shuttle.plugins.ameriflux import AmeriFluxPlugin
 
-        async def mock_iter_chunked(size):
+        async def mock_download_file(*_args, **_kwargs):
             for chunk in [b"test_data"]:
                 yield chunk
 
         with (
-            patch.object(AmeriFluxPlugin, "download_file") as mock_download_file,
+            patch.object(AmeriFluxPlugin, "download_file", side_effect=mock_download_file) as mock_download_file,
             patch("builtins.open", mock_open()),
         ):
-            # Create async mock stream
-            mock_stream = AsyncMock()
-            mock_stream.iter_chunked = mock_iter_chunked
-            mock_download_file.return_value.__aenter__.return_value = mock_stream
-
             # Pass user_info in kwargs
             user_info = {
                 "ameriflux": {
@@ -416,6 +366,117 @@ class TestDownloadDataset:
             assert result == "./test.zip"
 
 
+class TestFluxnetShuttleDownload:
+    """Test cases for the FluxnetShuttle download_dataset method."""
+
+    @pytest.mark.asyncio
+    async def test_download_dataset_successful(self):
+        """Test successful download through orchestrator."""
+        from unittest.mock import patch
+
+        from fluxnet_shuttle.core.shuttle import FluxnetShuttle
+        from fluxnet_shuttle.plugins.ameriflux import AmeriFluxPlugin
+
+        async def mock_download_file(*_args, **_kwargs):
+            yield b"test data"
+
+        with patch.object(AmeriFluxPlugin, "download_file", side_effect=mock_download_file) as mock_download_file:
+
+            shuttle = FluxnetShuttle()
+
+            # Test the new orchestrator method
+            chunks = []
+            async for chunk in shuttle.download_dataset(
+                site_id="US-Ha1",
+                data_hub="ameriflux",
+                download_link="https://example.com/test.zip",
+                filename="test.zip",
+            ):
+                chunks.append(chunk)
+
+            assert chunks == [b"test data"]
+            mock_download_file.assert_called_once_with(
+                site_id="US-Ha1", download_link="https://example.com/test.zip", filename="test.zip"
+            )
+
+    @pytest.mark.asyncio
+    async def test_download_dataset_plugin_not_found(self):
+        """Test download through orchestrator when plugin not found."""
+        from fluxnet_shuttle.core.shuttle import FluxnetShuttle
+
+        shuttle = FluxnetShuttle()
+
+        # Test with invalid data hub
+        with pytest.raises(ValueError, match="Data hub 'invalidhub' not configured"):
+            async for _ in shuttle.download_dataset(
+                site_id="US-TEST", data_hub="invalidhub", download_link="https://example.com/test.zip"
+            ):
+                pass  # Should not reach here
+
+    @pytest.mark.asyncio
+    async def test_download_dataset_error_collection(self):
+        """Test error collection in download orchestration."""
+        from unittest.mock import patch
+
+        from fluxnet_shuttle.core.shuttle import FluxnetShuttle
+        from fluxnet_shuttle.plugins.ameriflux import AmeriFluxPlugin
+
+        # Mock download_file to raise an exception
+        with patch.object(AmeriFluxPlugin, "download_file") as mock_download_file:
+            mock_download_file.side_effect = Exception("Download failed")
+
+            shuttle = FluxnetShuttle()
+
+            with pytest.raises(Exception, match="Download failed"):
+                async for _ in shuttle.download_dataset(
+                    site_id="US-Ha1", data_hub="ameriflux", download_link="https://example.com/test.zip"
+                ):
+                    pass  # Should not reach here
+
+    @pytest.mark.asyncio
+    async def test_download_dataset_existing_error_collector_adds_error(self):
+        """Test download orchestration overwrites existing collector with new errors."""
+        from unittest.mock import patch
+
+        from fluxnet_shuttle.core.shuttle import FluxnetShuttle
+        from fluxnet_shuttle.plugins.ameriflux import AmeriFluxPlugin
+
+        with patch.object(AmeriFluxPlugin, "download_file") as mock_download_file:
+            mock_download_file.side_effect = Exception("Download failed")
+
+            shuttle = FluxnetShuttle()
+            shuttle._last_error_collector = MagicMock()
+
+            with pytest.raises(Exception, match="Download failed"):
+                async for _ in shuttle.download_dataset(
+                    site_id="US-Ha1", data_hub="ameriflux", download_link="https://example.com/test.zip"
+                ):
+                    pass  # Should not reach here
+
+            errors = shuttle.get_errors()
+            assert errors.total_errors == 1
+            assert errors.errors[0].data_hub == "ameriflux"
+            assert errors.errors[0].operation == "download_file"
+            assert "Download failed" in errors.errors[0].error
+
+    @pytest.mark.asyncio
+    async def test_download_dataset_missing_download_file(self):
+        """Test download orchestration when plugin lacks download_file."""
+        from fluxnet_shuttle.core.shuttle import FluxnetShuttle
+
+        class NoDownloadPlugin:
+            name = "no_download"
+
+        shuttle = FluxnetShuttle()
+
+        with patch.object(shuttle, "_get_plugin_instance", return_value=NoDownloadPlugin()):
+            with pytest.raises(AttributeError, match="does not have 'download_file' method"):
+                async for _ in shuttle.download_dataset(
+                    site_id="US-Ha1", data_hub="ameriflux", download_link="https://example.com/test.zip"
+                ):
+                    pass  # Should not reach here
+
+
 class TestDownload:
     """Test cases for the download function."""
 
@@ -433,8 +494,8 @@ class TestDownload:
         # Mock the _download_dataset function to return coroutines
         with patch("fluxnet_shuttle.shuttle._download_dataset") as mock_download:
             # Create async mock that returns coroutines
-            async def mock_download_side_effect(*args, **kwargs):
-                return ["US-Ha1.zip", "US-MMS.zip"][mock_download.call_count - 1]
+            async def mock_download_side_effect(*_args, **kwargs):
+                return kwargs.get("filename", "")
 
             mock_download.side_effect = mock_download_side_effect
 


### PR DESCRIPTION
- Add download_dataset() method to FluxnetShuttle class in core/shuttle.py
- Refactor _download_dataset() in shuttle.py to use orchestrator instead of direct plugin calls
- Add error collection wrapper for download operations
- Add comprehensive tests for new orchestrator download functionality
- Remove unused registry import from shuttle.py

This ensures downloads follow same orchestrator pattern as site discovery, providing consistent error handling and plugin management across all operations.

Resolves: #94