### PR TITLE
fix(plugins): map ICOS SPARQL team member roles to BADM controlled vo…

### DIFF
--- a/src/fluxnet_shuttle/plugins/icos.py
+++ b/src/fluxnet_shuttle/plugins/icos.py
@@ -33,6 +33,15 @@ logger = logging.getLogger(__name__)
 
 # Constants from original ICOS module
 ICOS_API_URL = "https://meta.icos-cp.eu/sparql"
+
+# Mapping from ICOS SPARQL team member roles to BADM controlled vocabulary
+ICOS_ROLE_TO_BADM = {
+    "principal investigator": "PI",
+    "administrator": "PI",
+    "researcher": "FluxContact",
+    "data manager": "DataManager",
+    "engineer": "Technician",
+}
 ICOS_SPARQL_QUERY = """
 prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
 prefix prov: <http://www.w3.org/ns/prov#>
@@ -179,6 +188,22 @@ class ICOSPlugin(DataHubPlugin):
 
         return sites_data
 
+    def _map_icos_role_to_badm(self, icos_role: str) -> str:
+        """
+        Map ICOS SPARQL team member roles to BADM controlled vocabulary.
+
+        Args:
+            icos_role: Role name from ICOS SPARQL query
+
+        Returns:
+            BADM controlled vocabulary role (PI, FluxContact, DataManager, Technician, or Affiliate)
+        """
+        # Normalize role string by stripping whitespace and converting to lower case for comparison
+        normalized_role = icos_role.strip().lower()
+
+        # Return mapped role or "Affiliate" for blank/other values
+        return ICOS_ROLE_TO_BADM.get(normalized_role, "Affiliate")
+
     def _extract_team_member(self, binding: Dict[str, Any]) -> Optional[TeamMember]:
         """Extract team member information from SPARQL binding."""
         first_name = binding.get("firstName", {}).get("value", "")
@@ -191,9 +216,13 @@ class ICOSPlugin(DataHubPlugin):
         if not full_name:
             return None
 
+        # Get ICOS role and map to BADM controlled vocabulary
+        icos_role = binding.get("roleName", {}).get("value", "")
+        badm_role = self._map_icos_role_to_badm(icos_role)
+
         return TeamMember(
             team_member_name=full_name,
-            team_member_role=binding.get("roleName", {}).get("value", ""),
+            team_member_role=badm_role,
             team_member_email=binding.get("email", {}).get("value", ""),
         )
 

--- a/tests/test_plugin_icos.py
+++ b/tests/test_plugin_icos.py
@@ -335,14 +335,39 @@ class TestICOSPlugin:
         assert len(team_members) == 2
 
         assert team_members[0].team_member_name == "Gerald Jurasinski"
-        assert team_members[0].team_member_role == "Principal Investigator"
+        assert team_members[0].team_member_role == "PI"
         assert team_members[0].team_member_email == "gerald.jurasinski@uni-rostock.de"
 
         assert team_members[1].team_member_name == "Ute Karstens"
-        assert team_members[1].team_member_role == "Researcher"
+        assert team_members[1].team_member_role == "FluxContact"
         assert team_members[1].team_member_email == "ute.karstens@nateko.lu.se"
 
         assert mock_request.call_count == 1
+
+    def test_icos_role_to_badm_mapping(self):
+        """Test ICOS role to BADM controlled vocabulary mapping."""
+        plugin = ICOSPlugin()
+
+        # Test all defined mappings
+        assert plugin._map_icos_role_to_badm("Principal Investigator") == "PI"
+        assert plugin._map_icos_role_to_badm("Administrator") == "PI"
+        assert plugin._map_icos_role_to_badm("Researcher") == "FluxContact"
+        assert plugin._map_icos_role_to_badm("Data Manager") == "DataManager"
+        assert plugin._map_icos_role_to_badm("Engineer") == "Technician"
+
+        # Test case insensitivity
+        assert plugin._map_icos_role_to_badm("principal investigator") == "PI"
+        assert plugin._map_icos_role_to_badm("RESEARCHER") == "FluxContact"
+        assert plugin._map_icos_role_to_badm("data manager") == "DataManager"
+
+        # Test whitespace handling
+        assert plugin._map_icos_role_to_badm("  Principal Investigator  ") == "PI"
+        assert plugin._map_icos_role_to_badm("  researcher  ") == "FluxContact"
+
+        # Test default mapping for unknown/other roles
+        assert plugin._map_icos_role_to_badm("Unknown Role") == "Affiliate"
+        assert plugin._map_icos_role_to_badm("") == "Affiliate"
+        assert plugin._map_icos_role_to_badm("   ") == "Affiliate"
 
     @pytest.mark.asyncio
     @patch("fluxnet_shuttle.plugins.icos.DataHubPlugin._session_request")


### PR DESCRIPTION
…cabulary

- Add ICOS_ROLE_TO_BADM mapping constant for role conversion
- Implement _map_icos_role_to_badm() method with case-insensitive matching
- Map Principal Investigator and Administrator to PI
- Map Researcher to FluxContact
- Map Data Manager to DataManager
- Map Engineer to Technician
- Default to Affiliate for unknown or blank roles
- Update tests to verify BADM CV role mappings

Fixes #110