### PR TITLE
fix(core): ensure aiohttp session is closed on request failure

### DIFF
--- a/src/fluxnet_shuttle/core/http_utils.py
+++ b/src/fluxnet_shuttle/core/http_utils.py
@@ -48,8 +48,10 @@ async def get_session() -> AsyncGenerator[aiohttp.ClientSession, None]:
         sock_read=300,  # 5 minute read timeout to avoid TLS issues
     )
     session = aiohttp.ClientSession(timeout=client_timeout)
-    yield session
-    await session.close()
+    try:
+        yield session
+    finally:
+        await session.close()
 
 
 @asynccontextmanager


### PR DESCRIPTION
Wrap the yield in get_session() with try/finally so the ClientSession is always closed, even when an exception propagates through the context manager (e.g., a 504 from a plugin). Without this, failed requests leak the session and connector, producing "Unclosed client session" errors.

Resolves #113 