### PR TITLE
fix(src): parse snapshot CSV with csv.reader to handle quoted fields

### DIFF
--- a/src/fluxnet_shuttle/shuttle.py
+++ b/src/fluxnet_shuttle/shuttle.py
@@ -261,16 +261,13 @@ async def download(
         msg = f"Snapshot file {snapshot_file} does not exist."
         _log.error(msg)
         raise FLUXNETShuttleError(msg)
-    with open(snapshot_file, "r", encoding="utf-8", newline="\n") as f:
-        run_data: List[Any] = f.readlines()
-    run_data = [line.strip().split(",") for line in run_data]
-    fields = run_data[0]
-    sites = {}
-    for line in run_data[1:]:
-        site = {}
-        for i, field in enumerate(fields):
-            site[field] = line[i]
-        sites[site["site_id"]] = site
+    with open(snapshot_file, "r", encoding="utf-8", newline="") as f:
+        reader = csv.reader(f)
+        fields = next(reader)
+        sites = {}
+        for line in reader:
+            site = {field: line[i] for i, field in enumerate(fields)}
+            sites[site["site_id"]] = site
     _log.debug(f"Loaded {len(sites)} sites from snapshot file")
 
     # If no site IDs specified, download all sites from snapshot


### PR DESCRIPTION
Naive line.split(',') broke column alignment for sites whose site_name or product_citation contained a comma (e.g. CA-Gro, CA-Mer, CA-Qfo).  The shifted columns caused fluxnet_product_name to receive the raw download URL, which then produced an ENOENT error when the download function tried to open that string as a file path.

Replace the manual split with csv.reader (already imported), which correctly handles RFC 4180 quoted fields.

Refs: #115