### PR TITLE
fix(src): continue downloading remaining sites when one download fails

### DIFF
--- a/src/fluxnet_shuttle/shuttle.py
+++ b/src/fluxnet_shuttle/shuttle.py
@@ -322,8 +322,16 @@ async def download(
         )
         for job in download_jobs
     ]
-    downloaded_filenames = await asyncio.gather(*tasks)
-    _log.info(f"Downloaded data for {len(site_ids)} sites: {site_ids}")
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    downloaded_filenames: list[str] = []
+    for job, result in zip(download_jobs, results):
+        if isinstance(result, BaseException):
+            _log.error(f"Failed to download {job['filename']} for site {job['site_id']}: {result}")
+        else:
+            downloaded_filenames.append(result)
+
+    _log.info(f"Downloaded data for {len(downloaded_filenames)}/{len(download_jobs)} sites")
     return downloaded_filenames
 
 

--- a/tests/test_shuttle.py
+++ b/tests/test_shuttle.py
@@ -698,6 +698,36 @@ class TestDownload:
         assert "No filename found for site US-TEST" in caplog.text
         assert "Skipping download" in caplog.text
 
+    @pytest.mark.asyncio
+    @patch("fluxnet_shuttle.shuttle._download_dataset")
+    @patch("os.path.exists")
+    @patch(
+        "builtins.open",
+        mock_open(
+            read_data="site_id,data_hub,download_link,fluxnet_product_name\n"
+            "US-Ha1,AmeriFlux,http://example.com/US-Ha1.zip,US-Ha1.zip\n"
+            "US-MMS,AmeriFlux,http://example.com/US-MMS.zip,US-MMS.zip\n"
+        ),
+    )
+    async def test_download_partial_failure_continues(self, mock_exists, mock_download, caplog):
+        """Test that a failed download does not stop other downloads."""
+        mock_exists.return_value = True
+
+        async def mock_side_effect(*_args, **kwargs):
+            if kwargs.get("site_id") == "US-Ha1":
+                raise FLUXNETShuttleError("Failed to download")
+            return "US-MMS.zip"
+
+        mock_download.side_effect = mock_side_effect
+
+        with caplog.at_level("ERROR", logger="fluxnet_shuttle.shuttle"):
+            result = await download(["US-Ha1", "US-MMS"], "test.csv")
+
+        # Only the successful download should be in results
+        assert result == ["US-MMS.zip"]
+        assert mock_download.call_count == 2
+        assert "Failed to download US-Ha1.zip for site US-Ha1" in caplog.text
+
 
 class TestListall:
     """Test cases for the listall function."""


### PR DESCRIPTION
Use asyncio.gather with return_exceptions=True so that a single failed download logs an error instead of aborting all concurrent downloads.

Resolves #117 