### PR TITLE
feat(config): move hard-coded plugin URLs to YAML config file

### DIFF
--- a/src/fluxnet_shuttle/core/base.py
+++ b/src/fluxnet_shuttle/core/base.py
@@ -218,7 +218,7 @@ class DataHubPlugin(ABC):
 
         Example:
             >>> try:
-            ...     with await self._session_request('GET', 'https://api.example.com/data') as response:
+            ...     with await self._session_request('GET', 'https://amfcdn-dev.lbl.gov/api/data') as response:
             ...         data = await response.json()
             ... except PluginError as e:
             ...     print(f"Error occurred: {e}")

--- a/src/fluxnet_shuttle/core/config.py
+++ b/src/fluxnet_shuttle/core/config.py
@@ -29,9 +29,16 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class DataHubConfig:
-    """Configuration for a specific data hub."""
+    """Configuration for a specific data hub.
+
+    Stores the ``enabled`` flag plus any additional plugin-specific
+    settings (e.g. ``base_url``, ``api_url``).  Extra keys supplied
+    at construction time are kept in the ``settings`` dict and are
+    forwarded to the plugin instance via ``self.config``.
+    """
 
     enabled: bool = True
+    settings: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -73,7 +80,7 @@ class ShuttleConfig:
             config = cls()
             if "data_hubs" in config_dict:
                 for data_hub_name, data_hub_data in config_dict["data_hubs"].items():
-                    config.data_hubs[data_hub_name] = DataHubConfig(**data_hub_data)
+                    config.data_hubs[data_hub_name] = cls._parse_data_hub_config(data_hub_data)
 
             # Update other settings
             for key, value in config_dict.items():
@@ -110,7 +117,15 @@ class ShuttleConfig:
 
             if "data_hubs" in config_dict:
                 for data_hub_name, data_hub_data in config_dict["data_hubs"].items():
-                    config.data_hubs[data_hub_name] = DataHubConfig(**data_hub_data)
+                    if data_hub_name in config.data_hubs:
+                        # Merge: override only the keys specified in the file
+                        existing = config.data_hubs[data_hub_name]
+                        if "enabled" in data_hub_data:
+                            existing.enabled = data_hub_data["enabled"]
+                        override_settings = {k: v for k, v in data_hub_data.items() if k != "enabled"}
+                        existing.settings.update(override_settings)
+                    else:
+                        config.data_hubs[data_hub_name] = cls._parse_data_hub_config(data_hub_data)
 
             for key, value in config_dict.items():
                 if key != "data_hubs" and hasattr(config, key):
@@ -142,10 +157,22 @@ class ShuttleConfig:
         config = cls()
 
         for data_hub_name, data_hub_data in config_dict["data_hubs"].items():
-            config.data_hubs[data_hub_name] = DataHubConfig(**data_hub_data)
+            config.data_hubs[data_hub_name] = cls._parse_data_hub_config(data_hub_data)
 
         for key, value in config_dict.items():
             if key != "data_hubs" and hasattr(config, key):
                 setattr(config, key, value)
 
         return config
+
+    @staticmethod
+    def _parse_data_hub_config(data: Dict[str, Any]) -> "DataHubConfig":
+        """Parse a data hub config dict into a DataHubConfig.
+
+        Known fields (``enabled``) are set as dataclass attributes.
+        All other keys are stored in the ``settings`` dict so they
+        can be forwarded to the plugin instance.
+        """
+        enabled = data.get("enabled", True)
+        settings = {k: v for k, v in data.items() if k != "enabled"}
+        return DataHubConfig(enabled=enabled, settings=settings)

--- a/src/fluxnet_shuttle/core/shuttle.py
+++ b/src/fluxnet_shuttle/core/shuttle.py
@@ -246,5 +246,5 @@ class FluxnetShuttle:
         if not data_hub_config.enabled:
             raise ValueError(f"Data hub '{data_hub_name}' is disabled.")
 
-        plugin: DataHubPlugin = self.registry.create_instance(data_hub_name, **data_hub_config.__dict__)
+        plugin: DataHubPlugin = self.registry.create_instance(data_hub_name, **data_hub_config.settings)
         return plugin

--- a/src/fluxnet_shuttle/models.py
+++ b/src/fluxnet_shuttle/models.py
@@ -51,7 +51,7 @@ Example:
     >>> product_data = DataFluxnetProduct(
     ...     first_year=2005,
     ...     last_year=2025,
-    ...     download_link="https://example.com/data.zip",
+    ...     download_link="https://amfcdn-dev.lbl.gov/data.zip",
     ...     product_id="10.17190/AMF/1871137",
     ...     product_citation="J. William Munger (2025), AmeriFlux FLUXNET citation ...",
     ...     product_source_network="AMF",

--- a/src/fluxnet_shuttle/plugins/ameriflux.py
+++ b/src/fluxnet_shuttle/plugins/ameriflux.py
@@ -39,7 +39,10 @@ from ..shuttle import (
 
 logger = logging.getLogger(__name__)
 
-# Constants from original ameriflux module
+# Default AmeriFlux API endpoints.
+# Each constant below can be overridden per-deployment in config.yaml
+# under ``data_hubs.ameriflux.<key>``.  The plugin reads overrides via
+# ``self.config.get("<key>", DEFAULT)`` with these values as fallbacks.
 AMERIFLUX_BASE_URL = "https://amfcdn.lbl.gov/"
 AMERIFLUX_BASE_PATH = "api/v2/"
 AMERIFLUX_SITE_INFO_PATH = "site_info_display/AmeriFlux"
@@ -103,7 +106,9 @@ class AmeriFluxPlugin(DataHubPlugin):
         """
         logger.info("Fetching AmeriFlux sites...")
 
-        api_url = f"{AMERIFLUX_BASE_URL}{AMERIFLUX_BASE_PATH}"
+        base_url = self.config.get("base_url", AMERIFLUX_BASE_URL)
+        base_path = self.config.get("base_path", AMERIFLUX_BASE_PATH)
+        api_url = f"{base_url}{base_path}"
 
         try:
             site_metadata = await self._get_site_metadata(api_url)
@@ -145,8 +150,9 @@ class AmeriFluxPlugin(DataHubPlugin):
 
     async def _get_site_metadata(self, api_url: str) -> Dict[str, Any]:
         """Get site metadata including lat, lon, IGBP from v2 site_info_display endpoint."""
+        site_info_path = self.config.get("site_info_path", AMERIFLUX_SITE_INFO_PATH)
         try:
-            async with self._session_request("GET", f"{api_url}{AMERIFLUX_SITE_INFO_PATH}") as response:
+            async with self._session_request("GET", f"{api_url}{site_info_path}") as response:
                 data = await response.json()
                 # Create a dictionary indexed by site_id for quick lookup
                 site_dict = {}
@@ -164,7 +170,8 @@ class AmeriFluxPlugin(DataHubPlugin):
 
     async def _get_download_links(self, base_url: str, site_ids: List[str]) -> Dict[str, Any]:
         """Get download links for specified AmeriFlux sites using v2 shuttle endpoint."""
-        url_post_query = f"{base_url}{AMERIFLUX_DOWNLOAD_PATH}"
+        download_path = self.config.get("download_path", AMERIFLUX_DOWNLOAD_PATH)
+        url_post_query = f"{base_url}{download_path}"
 
         # V2 endpoint requires only: user_id, data_product, data_variant, site_ids
         json_query = {
@@ -196,7 +203,8 @@ class AmeriFluxPlugin(DataHubPlugin):
         Returns:
             Dictionary mapping site_id to citation string
         """
-        url_post_query = f"{base_url}{AMERIFLUX_CITATIONS_PATH}"
+        citations_path = self.config.get("citations_path", AMERIFLUX_CITATIONS_PATH)
+        url_post_query = f"{base_url}{citations_path}"
 
         json_query = {"site_ids": site_ids}
 
@@ -497,7 +505,10 @@ class AmeriFluxPlugin(DataHubPlugin):
             logger.warning("No filenames provided for AmeriFlux download tracking")
             return False
 
-        api_url = f"{AMERIFLUX_BASE_URL}{AMERIFLUX_BASE_PATH}{AMERIFLUX_LOG_PATH}"
+        base_url = self.config.get("base_url", AMERIFLUX_BASE_URL)
+        base_path = self.config.get("base_path", AMERIFLUX_BASE_PATH)
+        log_path = self.config.get("log_path", AMERIFLUX_LOG_PATH)
+        api_url = f"{base_url}{base_path}{log_path}"
 
         # Build tracking data payload with required fields
         tracking_data: Dict[str, Any] = {

--- a/src/fluxnet_shuttle/plugins/config.yaml
+++ b/src/fluxnet_shuttle/plugins/config.yaml
@@ -1,5 +1,11 @@
 # Default FLUXNET Shuttle Configuration
 # ====================================
+#
+# To override these defaults, create a custom YAML file and load it with:
+#   config = ShuttleConfig.load_from_file(Path("my-config.yaml"))
+#   shuttle = FluxnetShuttle(config=config)
+#
+# Only the keys you specify are overridden; everything else keeps its default.
 
 # Global settings
 parallel_requests: 3
@@ -8,9 +14,17 @@ parallel_requests: 3
 data_hubs:
   ameriflux:
     enabled: true
+    base_url: "https://amfcdn.lbl.gov/"
+    base_path: "api/v2/"
+    site_info_path: "site_info_display/AmeriFlux"
+    download_path: "amf_shuttle_data_files_and_manifest"
+    log_path: "log_shuttle_data_request"
+    citations_path: "citations/FLUXNET"
 
   icos:
     enabled: true
+    api_url: "https://meta.icos-cp.eu/sparql"
 
   tern:
     enabled: true
+    base_url: "https://dap.tern.org.au/thredds/fileServer/ecosystem_process/fluxnet/"

--- a/src/fluxnet_shuttle/plugins/icos.py
+++ b/src/fluxnet_shuttle/plugins/icos.py
@@ -31,7 +31,8 @@ from ..shuttle import (
 
 logger = logging.getLogger(__name__)
 
-# Constants from original ICOS module
+# Default ICOS SPARQL endpoint.
+# Can be overridden in config.yaml under ``data_hubs.icos.api_url``.
 ICOS_API_URL = "https://meta.icos-cp.eu/sparql"
 
 # Mapping from ICOS SPARQL team member roles to BADM controlled vocabulary

--- a/src/fluxnet_shuttle/plugins/tern.py
+++ b/src/fluxnet_shuttle/plugins/tern.py
@@ -35,7 +35,8 @@ from ..shuttle import (
 
 logger = logging.getLogger(__name__)
 
-# TERN data endpoints
+# Default TERN data endpoint.
+# Can be overridden in config.yaml under ``data_hubs.tern.base_url``.
 TERN_BASE_URL = "https://dap.tern.org.au/thredds/fileServer/ecosystem_process/fluxnet/"
 TERN_BIF_METADATA_URL = f"{TERN_BASE_URL}BIF_all_sites.csv"
 TERN_PRODUCT_METADATA_URL = f"{TERN_BASE_URL}TERN_THREDDS_catalogue.csv"
@@ -323,10 +324,12 @@ class TERNPlugin(DataHubPlugin):
         Raises:
             PluginError: If fetching or parsing fails
         """
-        logger.info(f"Fetching BIF metadata from {TERN_BIF_METADATA_URL}")
+        base_url = self.config.get("base_url", TERN_BASE_URL)
+        bif_metadata_url = f"{base_url}BIF_all_sites.csv"
+        logger.info(f"Fetching BIF metadata from {bif_metadata_url}")
 
         try:
-            async with self._session_request("GET", TERN_BIF_METADATA_URL) as response:
+            async with self._session_request("GET", bif_metadata_url) as response:
                 content = await response.text()
 
                 # Parse BIF content
@@ -362,10 +365,12 @@ class TERNPlugin(DataHubPlugin):
         Raises:
             PluginError: If fetching or parsing fails
         """
-        logger.info(f"Fetching product metadata from {TERN_PRODUCT_METADATA_URL}")
+        base_url = self.config.get("base_url", TERN_BASE_URL)
+        product_metadata_url = f"{base_url}TERN_THREDDS_catalogue.csv"
+        logger.info(f"Fetching product metadata from {product_metadata_url}")
 
         try:
-            async with self._session_request("GET", TERN_PRODUCT_METADATA_URL) as response:
+            async with self._session_request("GET", product_metadata_url) as response:
                 content = await response.text()
 
                 # Parse product metadata (returns all products per site, no selection yet)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,8 @@ import pytest
 def temp_csv_file():
     """Create a temporary CSV file for testing."""
     content = "site_id,data_hub,filename,download_link\n"
-    content += "US-TEST,AmeriFlux,test_ameriflux.zip,http://example.com/ameriflux.zip\n"
-    content += "IT-TEST,ICOS,test_icos.zip,http://example.com/icos.zip\n"
+    content += "US-TEST,AmeriFlux,test_ameriflux.zip,http://amfcdn-dev.lbl.gov/ameriflux.zip\n"
+    content += "IT-TEST,ICOS,test_icos.zip,http://amfcdn-dev.lbl.gov/icos.zip\n"
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
         f.write(content)
@@ -44,11 +44,11 @@ def sample_ameriflux_api_response():
         "data_urls": [
             {
                 "site_id": "US-TEST1",
-                "url": "http://example.com/FLX_US-TEST1_FLUXNET2015_FULLSET_" "2020-2023_1.zip",
+                "url": "http://amfcdn-dev.lbl.gov/FLX_US-TEST1_FLUXNET2015_FULLSET_" "2020-2023_1.zip",
             },
             {
                 "site_id": "US-TEST2",
-                "url": "http://example.com/FLX_US-TEST2_FLUXNET2015_FULLSET_" "2019-2022_2.zip",
+                "url": "http://amfcdn-dev.lbl.gov/FLX_US-TEST2_FLUXNET2015_FULLSET_" "2019-2022_2.zip",
             },
         ]
     }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -109,11 +109,11 @@ def sample_ameriflux_response():
         "data_urls": [
             {
                 "site_id": "US-ARM",
-                "url": "https://example.com/FLX_US-ARM_FLUXNET_2003-2012_v1_r0.zip",
+                "url": "https://amfcdn-dev.lbl.gov/FLX_US-ARM_FLUXNET_2003-2012_v1_r0.zip",
             },
             {
                 "site_id": "US-Ton",
-                "url": "https://example.com/FLX_US-Ton_FLUXNET_2001-2014_v1_r0.zip",
+                "url": "https://amfcdn-dev.lbl.gov/FLX_US-Ton_FLUXNET_2001-2014_v1_r0.zip",
             },
         ]
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -215,7 +215,9 @@ class TestCLIFunctions:
     @patch("fluxnet_shuttle.main.listall")
     def test_cmd_listall_basic(self, mock_listall):
         """Test cmd_listall function."""
-        mock_listall.return_value = [{"site_id": "US-Ha1", "data_hub": "AmeriFlux", "data_url": "http://example.com"}]
+        mock_listall.return_value = [
+            {"site_id": "US-Ha1", "data_hub": "AmeriFlux", "data_url": "http://amfcdn-dev.lbl.gov"}
+        ]
 
         # Create mock args
         args = argparse.Namespace(output="test_output.csv", logfile="test.log", no_logfile=False, verbose=False)
@@ -626,12 +628,12 @@ class TestCLIFunctions:
         from fluxnet_shuttle.main import _prompt_user_info
 
         # Mock user inputs in sequence
-        mock_input.side_effect = ["John Doe", "john@example.com", "2", "Testing the download system"]
+        mock_input.side_effect = ["John Doe", "john@amfcdn-dev.lbl.gov", "2", "Testing the download system"]
 
         result = _prompt_user_info(quiet=False)
 
         assert result["ameriflux"]["user_name"] == "John Doe"
-        assert result["ameriflux"]["user_email"] == "john@example.com"
+        assert result["ameriflux"]["user_email"] == "john@amfcdn-dev.lbl.gov"
         assert result["ameriflux"]["intended_use"] == 2  # Model
         assert result["ameriflux"]["description"] == "Testing the download system"
 
@@ -658,7 +660,7 @@ class TestCLIFunctions:
         from fluxnet_shuttle.main import _prompt_user_info
 
         # Mock invalid input followed by valid inputs
-        mock_input.side_effect = ["Test User", "test@example.com", "invalid", "Test description"]
+        mock_input.side_effect = ["Test User", "test@amfcdn-dev.lbl.gov", "invalid", "Test description"]
 
         result = _prompt_user_info(quiet=False)
 
@@ -673,7 +675,7 @@ class TestCLIFunctions:
         from fluxnet_shuttle.main import _prompt_user_info
 
         # Mock out-of-range input
-        mock_input.side_effect = ["User", "user@example.com", "99", "Description"]
+        mock_input.side_effect = ["User", "user@amfcdn-dev.lbl.gov", "99", "Description"]
 
         result = _prompt_user_info(quiet=False)
 
@@ -700,12 +702,12 @@ class TestCLIFunctions:
         from fluxnet_shuttle.main import _prompt_user_info
 
         # User provides name and email but skips intended_use and description
-        mock_input.side_effect = ["Jane Smith", "jane@example.com", "", ""]
+        mock_input.side_effect = ["Jane Smith", "jane@amfcdn-dev.lbl.gov", "", ""]
 
         result = _prompt_user_info(quiet=False)
 
         assert result["ameriflux"]["user_name"] == "Jane Smith"
-        assert result["ameriflux"]["user_email"] == "jane@example.com"
+        assert result["ameriflux"]["user_email"] == "jane@amfcdn-dev.lbl.gov"
         # Empty fields are not included
         assert "intended_use" not in result["ameriflux"]
         assert "description" not in result["ameriflux"]
@@ -716,11 +718,11 @@ class TestCLIFunctions:
         from fluxnet_shuttle.main import _prompt_user_info
 
         # Mock inputs with extra whitespace
-        mock_input.side_effect = ["  John Doe  ", "  john@example.com  ", "1", "  Test  "]
+        mock_input.side_effect = ["  John Doe  ", "  john@amfcdn-dev.lbl.gov  ", "1", "  Test  "]
 
         result = _prompt_user_info(quiet=False)
 
         # Should strip whitespace
         assert result["ameriflux"]["user_name"] == "John Doe"
-        assert result["ameriflux"]["user_email"] == "john@example.com"
+        assert result["ameriflux"]["user_email"] == "john@amfcdn-dev.lbl.gov"
         assert result["ameriflux"]["description"] == "Test"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -45,7 +45,7 @@ class MockDataHubPlugin(DataHubPlugin):
         product_data = DataFluxnetProduct(
             first_year=2020,
             last_year=2021,
-            download_link="https://example.com/test.zip",
+            download_link="https://amfcdn-dev.lbl.gov/test.zip",
             product_citation="Test citation",
             product_id="test-id",
             oneflux_code_version="v1",
@@ -152,7 +152,7 @@ class TestDataHubPlugin:
     async def test_session_request_success(self, mock_session_request):
         """Test successful _session_request call."""
         plugin = MockDataHubPlugin()
-        url = "https://api.example.com/data"
+        url = "https://amfcdn-dev.lbl.gov/api/data"
 
         # Mock the response
         mock_response = AsyncMock()
@@ -174,7 +174,7 @@ class TestDataHubPlugin:
     async def test_session_request_client_error(self, mock_session_request):
         """Test _session_request handling of aiohttp.ClientError."""
         plugin = MockDataHubPlugin()
-        url = "https://api.example.com/data"
+        url = "https://amfcdn-dev.lbl.gov/api/data"
 
         # Make session_request raise a ClientError when entered
         mock_session_request.return_value.__aenter__.side_effect = aiohttp.ClientConnectionError("Connection failed")
@@ -193,7 +193,7 @@ class TestDataHubPlugin:
     async def test_session_request_unexpected_error(self, mock_session_request):
         """Test _session_request handling of unexpected errors."""
         plugin = MockDataHubPlugin()
-        url = "https://api.example.com/data"
+        url = "https://amfcdn-dev.lbl.gov/api/data"
 
         # Make session_request raise a generic exception
         mock_session_request.side_effect = ValueError("Unexpected error")
@@ -212,7 +212,7 @@ class TestDataHubPlugin:
     async def test_default_download_file(self, mock_session_request):
         """Test default download_stream implementation in base class."""
         plugin = MockDataHubPlugin()
-        download_link = "https://example.com/file.zip"
+        download_link = "https://amfcdn-dev.lbl.gov/file.zip"
 
         # Mock the response with content
         mock_response = AsyncMock()
@@ -295,6 +295,70 @@ class TestShuttleConfig:
         assert "ameriflux" in config.data_hubs
         assert "icos" in config.data_hubs
         assert "tern" in config.data_hubs
+
+    def test_data_hub_config_settings(self):
+        """Test DataHubConfig stores plugin-specific settings."""
+        hub_config = DataHubConfig(enabled=True, settings={"base_url": "https://amfcdn-dev.lbl.gov/"})
+
+        assert hub_config.enabled is True
+        assert hub_config.settings["base_url"] == "https://amfcdn-dev.lbl.gov/"
+
+    def test_parse_data_hub_config_with_extra_keys(self):
+        """Test _parse_data_hub_config separates enabled from settings."""
+        data = {"enabled": True, "base_url": "https://amfcdn-dev.lbl.gov/", "api_path": "v2/"}
+        hub_config = ShuttleConfig._parse_data_hub_config(data)
+
+        assert hub_config.enabled is True
+        assert hub_config.settings == {"base_url": "https://amfcdn-dev.lbl.gov/", "api_path": "v2/"}
+
+    def test_load_from_file_merges_settings(self, tmp_path):
+        """Test that load_from_file merges plugin settings with defaults."""
+        config_path = tmp_path / "override.yaml"
+        config_path.write_text("""
+            data_hubs:
+              ameriflux:
+                base_url: "https://amfcdn-dev.lbl.gov/"
+            """)
+
+        config = ShuttleConfig.load_from_file(config_path)
+
+        # Ameriflux should have the overridden base_url
+        assert config.data_hubs["ameriflux"].settings["base_url"] == "https://amfcdn-dev.lbl.gov/"
+        # Should still be enabled (default)
+        assert config.data_hubs["ameriflux"].enabled is True
+        # Other hubs should still exist from defaults
+        assert "icos" in config.data_hubs
+        assert "tern" in config.data_hubs
+
+    def test_load_from_file_new_data_hub(self, tmp_path):
+        """Test that load_from_file can add a new data hub not in defaults."""
+        config_path = tmp_path / "new_hub.yaml"
+        config_path.write_text("""
+            data_hubs:
+              custom_hub:
+                enabled: true
+                api_url: "https://amfcdn-dev.lbl.gov/"
+            """)
+
+        config = ShuttleConfig.load_from_file(config_path)
+
+        assert "custom_hub" in config.data_hubs
+        assert config.data_hubs["custom_hub"].enabled is True
+        assert config.data_hubs["custom_hub"].settings["api_url"] == "https://amfcdn-dev.lbl.gov/"
+        # Defaults should still be present
+        assert "ameriflux" in config.data_hubs
+
+    def test_default_config_loads_plugin_settings(self):
+        """Test that default config loads plugin-specific settings from config.yaml."""
+        config = ShuttleConfig.load_default()
+
+        # AmeriFlux should have settings from config.yaml
+        assert "base_url" in config.data_hubs["ameriflux"].settings
+        assert config.data_hubs["ameriflux"].settings["base_url"] == "https://amfcdn.lbl.gov/"
+        # ICOS should have api_url
+        assert config.data_hubs["icos"].settings["api_url"] == "https://meta.icos-cp.eu/sparql"
+        # TERN should have base_url
+        assert "base_url" in config.data_hubs["tern"].settings
 
 
 class TestExceptions:

--- a/tests/test_core_shuttle.py
+++ b/tests/test_core_shuttle.py
@@ -67,7 +67,7 @@ class MockSuccessPlugin:
             product_data = DataFluxnetProduct(
                 first_year=2019,
                 last_year=2020,
-                download_link="https://example.com/success.zip",
+                download_link="https://amfcdn-dev.lbl.gov/success.zip",
                 product_citation="Test citation",
                 product_id="test-id",
                 oneflux_code_version="v1",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,7 +41,7 @@ def sample_product_data():
     return DataFluxnetProduct(
         first_year=2018,
         last_year=2023,
-        download_link="https://example.com/dataset.zip",
+        download_link="https://amfcdn-dev.lbl.gov/dataset.zip",
         product_citation="Test citation",
         product_id="test-id-123",
         oneflux_code_version="v1",
@@ -173,7 +173,7 @@ def test_data_fluxnet_product_valid_creation(sample_product_data):
     """Test creating a valid DataFluxnetProduct instance."""
     assert sample_product_data.first_year == 2018
     assert sample_product_data.last_year == 2023
-    assert str(sample_product_data.download_link) == "https://example.com/dataset.zip"
+    assert str(sample_product_data.download_link) == "https://amfcdn-dev.lbl.gov/dataset.zip"
 
 
 def test_data_fluxnet_product_year_validation():
@@ -184,7 +184,7 @@ def test_data_fluxnet_product_year_validation():
         product = DataFluxnetProduct(
             first_year=first_year,
             last_year=last_year,
-            download_link="https://example.com/dataset.zip",
+            download_link="https://amfcdn-dev.lbl.gov/dataset.zip",
             product_citation="Test citation",
             product_id="test-id",
             oneflux_code_version="v1",
@@ -199,7 +199,7 @@ def test_data_fluxnet_product_year_validation():
         DataFluxnetProduct(
             first_year=1899,  # Below minimum
             last_year=2000,
-            download_link="https://example.com/dataset.zip",
+            download_link="https://amfcdn-dev.lbl.gov/dataset.zip",
             product_citation="Test citation",
             product_id="test-id",
             oneflux_code_version="v1",
@@ -211,7 +211,7 @@ def test_data_fluxnet_product_year_validation():
         DataFluxnetProduct(
             first_year=2000,
             last_year=2101,  # Above maximum
-            download_link="https://example.com/dataset.zip",
+            download_link="https://amfcdn-dev.lbl.gov/dataset.zip",
             product_citation="Test citation",
             product_id="test-id",
             oneflux_code_version="v1",
@@ -224,7 +224,7 @@ def test_data_fluxnet_product_year_validation():
         DataFluxnetProduct(
             first_year=2023,
             last_year=2020,
-            download_link="https://example.com/dataset.zip",
+            download_link="https://amfcdn-dev.lbl.gov/dataset.zip",
             product_citation="Test citation",
             product_id="test-id",
             oneflux_code_version="v1",
@@ -237,7 +237,7 @@ def test_data_fluxnet_product_url_validation():
     """Test download link URL validation."""
     # Valid URLs
     valid_urls = [
-        "https://example.com/dataset.zip",
+        "https://amfcdn-dev.lbl.gov/dataset.zip",
         "http://ameriflux.lbl.gov/data/dataset.tar.gz",
         "https://icos-cp.eu/data/file.nc",
     ]
@@ -258,7 +258,7 @@ def test_data_fluxnet_product_url_validation():
     invalid_urls = [
         "not-a-url",
         "just-text",
-        "www.example.com",  # Missing protocol
+        "www.amfcdn-dev.lbl.gov",  # Missing protocol
         "ftp://server.com/data.zip",  # FTP not supported by HttpUrl
         "",
     ]
@@ -299,7 +299,7 @@ def test_fluxnet_dataset_metadata_nested_validation():
             product_data=DataFluxnetProduct(
                 first_year=2018,
                 last_year=2023,
-                download_link="https://example.com/dataset.zip",
+                download_link="https://amfcdn-dev.lbl.gov/dataset.zip",
                 product_citation="Test citation",
                 product_id="test-id",
                 oneflux_code_version="v1",
@@ -322,7 +322,7 @@ def test_fluxnet_dataset_metadata_nested_validation():
             product_data=DataFluxnetProduct(
                 first_year=2023,
                 last_year=2020,  # Invalid range
-                download_link="https://example.com/dataset.zip",
+                download_link="https://amfcdn-dev.lbl.gov/dataset.zip",
                 product_citation="Test citation",
                 product_id="test-id",
                 oneflux_code_version="v1",
@@ -352,7 +352,7 @@ def test_product_data_json_serialization(sample_product_data):
     json_data = sample_product_data.model_dump(mode="json")
     assert json_data["first_year"] == 2018
     assert json_data["last_year"] == 2023
-    assert json_data["download_link"] == "https://example.com/dataset.zip"
+    assert json_data["download_link"] == "https://amfcdn-dev.lbl.gov/dataset.zip"
 
     # Test round-trip
     reconstructed = DataFluxnetProduct(**json_data)

--- a/tests/test_plugin_ameriflux.py
+++ b/tests/test_plugin_ameriflux.py
@@ -107,7 +107,7 @@ class TestAmeriFluxPlugin:
             "data_urls": [
                 {
                     "site_id": "US-XYZ",
-                    "url": "http://example.com/US-XYZ_invalidformat.zip",
+                    "url": "http://amfcdn-dev.lbl.gov/US-XYZ_invalidformat.zip",
                 }
             ]
         }
@@ -150,7 +150,10 @@ class TestAmeriFluxPlugin:
         }
         mock_get_links.return_value = {
             "data_urls": [
-                {"site_id": "US-ABC", "url": "http://example.com/AMF_US-ABC_FLUXNET_2005-2012_v3_r7.zip"},
+                {
+                    "site_id": "US-ABC",
+                    "url": "http://amfcdn-dev.lbl.gov/AMF_US-ABC_FLUXNET_2005-2012_v3_r7.zip",
+                },
                 # Missing entry for US-DEF to simulate failure
             ]
         }
@@ -161,7 +164,10 @@ class TestAmeriFluxPlugin:
 
         assert len(sites) == 1
         assert sites[0].site_info.site_id == "US-ABC"
-        assert str(sites[0].product_data.download_link) == "http://example.com/AMF_US-ABC_FLUXNET_2005-2012_v3_r7.zip"
+        assert (
+            str(sites[0].product_data.download_link)
+            == "http://amfcdn-dev.lbl.gov/AMF_US-ABC_FLUXNET_2005-2012_v3_r7.zip"
+        )
         assert sites[0].site_info.data_hub == "AmeriFlux"
         assert sites[0].site_info.location_lat == 40.0  # From metadata
         assert sites[0].site_info.location_long == -100.0  # From metadata
@@ -235,7 +241,7 @@ class TestAmeriFluxPlugin:
         mock_response.raise_for_status.side_effect = None
         mock_request.return_value.__aenter__.return_value = mock_response
 
-        metadata = await ameriflux.AmeriFluxPlugin()._get_site_metadata(api_url="http://example.com")
+        metadata = await ameriflux.AmeriFluxPlugin()._get_site_metadata(api_url="http://amfcdn-dev.lbl.gov")
         assert "US-Tst" in metadata
         assert "US-EXM" in metadata
         assert metadata["US-Tst"]["grp_location"]["location_lat"] == "40.0"
@@ -248,7 +254,7 @@ class TestAmeriFluxPlugin:
     async def test__get_site_metadata_failure(self, mock_request):
         """Test _get_site_metadata raises PluginError on failure."""
         with pytest.raises(PluginError) as exc_info:
-            await ameriflux.AmeriFluxPlugin()._get_site_metadata(api_url="http://example.com")
+            await ameriflux.AmeriFluxPlugin()._get_site_metadata(api_url="http://amfcdn-dev.lbl.gov")
 
         assert "ameriflux" in str(exc_info.value).lower()
         assert mock_request.call_count == 1  # Ensure the request was attempted
@@ -261,7 +267,9 @@ class TestAmeriFluxPlugin:
     async def test__get_download_links_with_failure(self, mock_request):
         """Test _get_download_links raises PluginError on failure."""
         with pytest.raises(PluginError) as exc_info:
-            await ameriflux.AmeriFluxPlugin()._get_download_links(base_url="http://example.com", site_ids=["US-Tst"])
+            await ameriflux.AmeriFluxPlugin()._get_download_links(
+                base_url="http://amfcdn-dev.lbl.gov", site_ids=["US-Tst"]
+            )
 
         assert "ameriflux" in str(exc_info.value).lower()
         assert mock_request.call_count == 1  # Ensure the request was attempted
@@ -276,23 +284,36 @@ class TestAmeriFluxPlugin:
 
         async def mock_json():
             return {
-                "data_urls": [{"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip"}]
+                "data_urls": [
+                    {
+                        "site_id": "US-Tst",
+                        "url": "http://amfcdn-dev.lbl.gov/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip",
+                    }
+                ]
             }
 
         mock_response.json = mock_json
 
         links = await ameriflux.AmeriFluxPlugin()._get_download_links(
-            base_url="http://example.com", site_ids=["US-Tst"]
+            base_url="http://amfcdn-dev.lbl.gov", site_ids=["US-Tst"]
         )
         assert links == {
-            "data_urls": [{"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip"}]
+            "data_urls": [
+                {
+                    "site_id": "US-Tst",
+                    "url": "http://amfcdn-dev.lbl.gov/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip",
+                }
+            ]
         }
 
     def test_parse_response_with_invalid_format(self):
         """Test _parse_response method skips invalid entries and continues processing."""
         sample_response = {
             "data_urls": [
-                {"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip"},
+                {
+                    "site_id": "US-Tst",
+                    "url": "http://amfcdn-dev.lbl.gov/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip",
+                },
                 {
                     "site_id": "",
                 },  # Invalid format - missing 'url' key (should be skipped)
@@ -316,15 +337,24 @@ class TestAmeriFluxPlugin:
         assert results[0].site_info.site_id == "US-Tst"
         assert results[0].product_data.first_year == 2005
         assert results[0].product_data.last_year == 2012
-        assert str(results[0].product_data.download_link) == "http://example.com/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip"
+        assert (
+            str(results[0].product_data.download_link)
+            == "http://amfcdn-dev.lbl.gov/AMF_US-Tst_FLUXNET_2005-2012_v3_r7.zip"
+        )
         assert results[0].site_info.data_hub == "AmeriFlux"
 
     def test_parse_response_filters_sites_without_publish_years(self):
         """Test _parse_response filters out sites with no publish years and invalid filenames."""
         sample_response = {
             "data_urls": [
-                {"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2005-2007_v1_r0.zip"},
-                {"site_id": "US-NODATA", "url": "http://example.com/AMF_US-NODATA_FLUXNET_2010-2015_v1_r0.zip"},
+                {
+                    "site_id": "US-Tst",
+                    "url": "http://amfcdn-dev.lbl.gov/AMF_US-Tst_FLUXNET_2005-2007_v1_r0.zip",
+                },
+                {
+                    "site_id": "US-NODATA",
+                    "url": "http://amfcdn-dev.lbl.gov/AMF_US-NODATA_FLUXNET_2010-2015_v1_r0.zip",
+                },
             ]
         }
         site_metadata = {
@@ -384,7 +414,10 @@ class TestAmeriFluxPlugin:
         """Test _parse_response handles invalid lat/lon values gracefully."""
         sample_response = {
             "data_urls": [
-                {"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2005-2006_v1_r0.zip"},
+                {
+                    "site_id": "US-Tst",
+                    "url": "http://amfcdn-dev.lbl.gov/AMF_US-Tst_FLUXNET_2005-2006_v1_r0.zip",
+                },
             ]
         }
         site_metadata = {
@@ -413,7 +446,7 @@ class TestAmeriFluxPlugin:
         with pytest.raises(ValueError) as exc_info:
             plugin._build_product_data(
                 [],
-                "http://example.com/test.zip",
+                "http://amfcdn-dev.lbl.gov/test.zip",
                 product_id="test-id",
                 citation="test citation",
                 oneflux_code_version="v1",
@@ -437,7 +470,9 @@ class TestAmeriFluxPlugin:
                 "grp_publish_fluxnet": [2020, 2021],
             }
         }
-        mock_get_links.return_value = {"data_urls": [{"site_id": "US-Tst", "url": "http://example.com/test.zip"}]}
+        mock_get_links.return_value = {
+            "data_urls": [{"site_id": "US-Tst", "url": "http://amfcdn-dev.lbl.gov/test.zip"}]
+        }
         mock_get_citations.return_value = {"US-Tst": "Citation for US-Tst"}
 
         plugin = ameriflux.AmeriFluxPlugin()
@@ -480,9 +515,18 @@ class TestAmeriFluxPlugin:
         }
         mock_get_links.return_value = {
             "data_urls": [
-                {"site_id": "US-Ts1", "url": "http://example.com/AMF_US-Ts1_FLUXNET_2010-2012_v1_r0.zip"},
-                {"site_id": "US-Ts2", "url": "http://example.com/AMF_US-Ts2_FLUXNET_2020-2021_v1_r0.zip"},
-                {"site_id": "US-Ts3", "url": "http://example.com/AMF_US-Ts3_FLUXNET_2020-2021_v1_r0.zip"},
+                {
+                    "site_id": "US-Ts1",
+                    "url": "http://amfcdn-dev.lbl.gov/AMF_US-Ts1_FLUXNET_2010-2012_v1_r0.zip",
+                },
+                {
+                    "site_id": "US-Ts2",
+                    "url": "http://amfcdn-dev.lbl.gov/AMF_US-Ts2_FLUXNET_2020-2021_v1_r0.zip",
+                },
+                {
+                    "site_id": "US-Ts3",
+                    "url": "http://amfcdn-dev.lbl.gov/AMF_US-Ts3_FLUXNET_2020-2021_v1_r0.zip",
+                },
             ]
         }
         mock_get_citations.return_value = {
@@ -666,7 +710,7 @@ class TestAmeriFluxPlugin:
         mock_response.json = mock_json
 
         citations = await ameriflux.AmeriFluxPlugin()._get_citations(
-            base_url="http://example.com/", site_ids=["US-Ha1", "US-MMS"]
+            base_url="http://amfcdn-dev.lbl.gov/", site_ids=["US-Ha1", "US-MMS"]
         )
         assert citations == {"US-Ha1": "Citation for US-Ha1", "US-MMS": "Citation for US-MMS"}
 
@@ -678,7 +722,7 @@ class TestAmeriFluxPlugin:
     async def test__get_citations_failure(self, mock_request):
         """Test _get_citations handles failure gracefully and returns empty dict."""
         citations = await ameriflux.AmeriFluxPlugin()._get_citations(
-            base_url="http://example.com/", site_ids=["US-Ha1"]
+            base_url="http://amfcdn-dev.lbl.gov/", site_ids=["US-Ha1"]
         )
 
         assert citations == {}  # Should return empty dict on failure
@@ -692,7 +736,7 @@ class TestAmeriFluxPlugin:
     async def test__get_citations_generic_exception(self, mock_request):
         """Test _get_citations handles generic exceptions gracefully."""
         citations = await ameriflux.AmeriFluxPlugin()._get_citations(
-            base_url="http://example.com/", site_ids=["US-Ha1"]
+            base_url="http://amfcdn-dev.lbl.gov/", site_ids=["US-Ha1"]
         )
 
         assert citations == {}  # Should return empty dict on generic exception
@@ -722,7 +766,12 @@ class TestAmeriFluxPlugin:
             }
         }
         mock_get_links.return_value = {
-            "data_urls": [{"site_id": "US-Tst", "url": "http://example.com/AMF_US-Tst_FLUXNET_2020-2020_v1_r0.zip"}]
+            "data_urls": [
+                {
+                    "site_id": "US-Tst",
+                    "url": "http://amfcdn-dev.lbl.gov/AMF_US-Tst_FLUXNET_2020-2020_v1_r0.zip",
+                }
+            ]
         }
         mock_get_citations.return_value = {"US-Tst": "Citation for US-Tst"}
 
@@ -742,7 +791,10 @@ class TestAmeriFluxPlugin:
         """Test that debug logging is triggered when publish years are missing."""
         sample_response = {
             "data_urls": [
-                {"site_id": "US-NoY", "url": "http://example.com/AMF_US-NoY_FLUXNET_2020-2021_v1_r0.zip"},
+                {
+                    "site_id": "US-NoY",
+                    "url": "http://amfcdn-dev.lbl.gov/AMF_US-NoY_FLUXNET_2020-2021_v1_r0.zip",
+                },
             ]
         }
         site_metadata = {
@@ -795,7 +847,7 @@ class TestAmeriFluxPlugin:
         result = await plugin._log_download_request(
             zip_filenames=["file1.zip", "file2.zip"],
             user_name="Test User",
-            user_email="test@example.com",
+            user_email="test@amfcdn-dev.lbl.gov",
             intended_use=1,
             description="Test download",
         )
@@ -825,7 +877,7 @@ class TestAmeriFluxPlugin:
         mock_get_session.return_value.__aexit__ = AsyncMock(return_value=False)
 
         result = await plugin._log_download_request(
-            zip_filenames=["file1.zip"], user_name="Test User", user_email="test@example.com"
+            zip_filenames=["file1.zip"], user_name="Test User", user_email="test@amfcdn-dev.lbl.gov"
         )
 
         assert result is False
@@ -840,7 +892,7 @@ class TestAmeriFluxPlugin:
         mock_get_session.side_effect = Exception("Network error")
 
         result = await plugin._log_download_request(
-            zip_filenames=["file1.zip"], user_name="Test User", user_email="test@example.com"
+            zip_filenames=["file1.zip"], user_name="Test User", user_email="test@amfcdn-dev.lbl.gov"
         )
 
         assert result is False
@@ -870,12 +922,12 @@ class TestAmeriFluxPlugin:
         chunks = []
         async for chunk in plugin.download_file(
             site_id="US-Ha1",
-            download_link="https://example.com/file.zip",
+            download_link="https://amfcdn-dev.lbl.gov/file.zip",
             filename="test.zip",
             user_info={
                 "ameriflux": {
                     "user_name": "Test User",
-                    "user_email": "test@example.com",
+                    "user_email": "test@amfcdn-dev.lbl.gov",
                     "intended_use": 1,
                     "description": "Test download",
                 }
@@ -888,7 +940,7 @@ class TestAmeriFluxPlugin:
         mock_log_download.assert_called_once_with(
             zip_filenames=["test.zip"],
             user_name="Test User",
-            user_email="test@example.com",
+            user_email="test@amfcdn-dev.lbl.gov",
             intended_use=1,
             description="Test download",
         )
@@ -919,12 +971,12 @@ class TestAmeriFluxPlugin:
             chunks = []
             async for chunk in plugin.download_file(
                 site_id="US-Ha1",
-                download_link="https://example.com/file.zip",
+                download_link="https://amfcdn-dev.lbl.gov/file.zip",
                 filename="test.zip",
                 user_info={
                     "ameriflux": {
                         "user_name": "Test User",
-                        "user_email": "test@example.com",
+                        "user_email": "test@amfcdn-dev.lbl.gov",
                     }
                 },
             ):
@@ -954,7 +1006,7 @@ class TestAmeriFluxPlugin:
         # Call without user tracking - should not attempt logging
         chunks = []
         async for chunk in plugin.download_file(
-            site_id="US-Ha1", download_link="https://example.com/file.zip", filename="test.zip"
+            site_id="US-Ha1", download_link="https://amfcdn-dev.lbl.gov/file.zip", filename="test.zip"
         ):
             chunks.append(chunk)
         assert chunks == [b"test content"]

--- a/tests/test_plugin_tern.py
+++ b/tests/test_plugin_tern.py
@@ -608,10 +608,10 @@ AU-Lox,19,UTC_OFFSET,UTC_OFFSET,invalid_offset"""
         content = """SITE_ID,GROUP_ID,VARIABLE_GROUP,VARIABLE,DATAVALUE
 AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_NAME,First Member
 AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_ROLE,PI
-AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_EMAIL,first@example.com
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_EMAIL,first@amfcdn-dev.lbl.gov
 AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_NAME,Second Member
 AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_ROLE,Technician
-AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_EMAIL,second@example.com"""
+AU-Lox,16,TEAM_MEMBER,TEAM_MEMBER_EMAIL,second@amfcdn-dev.lbl.gov"""
 
         parser = tern.BIFParser()
         parsed_data = parser.parse_bif_content(content)

--- a/tests/test_shuttle.py
+++ b/tests/test_shuttle.py
@@ -22,7 +22,7 @@ class TestExtractFilenameFromUrl:
 
     def test_simple_url_without_query_params(self):
         """Test URL without query parameters."""
-        url = "https://example.com/path/to/file.zip"
+        url = "https://amfcdn-dev.lbl.gov/path/to/file.zip"
         result = _extract_filename_from_url(url)
         assert result == "file.zip"
 
@@ -43,13 +43,13 @@ class TestExtractFilenameFromUrl:
 
     def test_url_with_encoded_characters(self):
         """Test URL with percent-encoded characters."""
-        url = "https://example.com/path/file%20name.zip"
+        url = "https://amfcdn-dev.lbl.gov/path/file%20name.zip"
         result = _extract_filename_from_url(url)
         assert result == "file name.zip"
 
     def test_url_with_multiple_query_params(self):
         """Test URL with multiple query parameters."""
-        url = "https://example.com/download/data.csv?param1=value1&param2=value2"
+        url = "https://amfcdn-dev.lbl.gov/download/data.csv?param1=value1&param2=value2"
         result = _extract_filename_from_url(url)
         assert result == "data.csv"
 
@@ -79,7 +79,7 @@ class TestExtractFluxnetFilenameMetadata:
 
     def test_valid_filename_with_url(self):
         """Test extracting metadata from full URL."""
-        url = "https://example.com/AMF_AR-Bal_FLUXNET_2012-2013_v3_r7.zip"
+        url = "https://amfcdn-dev.lbl.gov/AMF_AR-Bal_FLUXNET_2012-2013_v3_r7.zip"
         source_network, version, first_year, last_year, run = extract_fluxnet_filename_metadata(url)
         assert source_network == "AMF"
         assert version == "v3"
@@ -142,7 +142,7 @@ class TestValidateFluxnetFilenameFormat:
 
     def test_valid_format_with_url(self):
         """Test valid filename within URL."""
-        url = "https://example.com/AMF_AR-Bal_FLUXNET_2012-2013_v3_r7.zip"
+        url = "https://amfcdn-dev.lbl.gov/AMF_AR-Bal_FLUXNET_2012-2013_v3_r7.zip"
         assert validate_fluxnet_filename_format(url) is True
 
     def test_invalid_format(self):
@@ -181,7 +181,7 @@ class TestDownloadDataset:
             patch.object(AmeriFluxPlugin, "download_file", side_effect=mock_download_file) as mock_download_file,
             patch("builtins.open", mock_open()),
         ):
-            result = await _download_dataset("US-TEST", "AmeriFlux", "test.zip", "http://example.com/test.zip")
+            result = await _download_dataset("US-TEST", "AmeriFlux", "test.zip", "http://amfcdn-dev.lbl.gov/test.zip")
 
             assert result == "./test.zip"
 
@@ -218,7 +218,9 @@ class TestDownloadDataset:
             patch.object(ICOSPlugin, "download_file", side_effect=mock_download_file) as mock_download_file,
             patch("builtins.open", mock_open()),
         ):
-            result = await _download_dataset("FI-HYY", "ICOS", "metadata_file.zip", "http://example.com/download")
+            result = await _download_dataset(
+                "FI-HYY", "ICOS", "metadata_file.zip", "http://amfcdn-dev.lbl.gov/download"
+            )
 
             # Should use filename from metadata (the one passed as argument)
             assert result == "./metadata_file.zip"
@@ -234,7 +236,7 @@ class TestDownloadDataset:
             mock_download_file.side_effect = PluginError("ameriflux", "HTTP 404 Not Found")
 
             with pytest.raises(FLUXNETShuttleError, match="Failed to download"):
-                await _download_dataset("US-TEST", "AmeriFlux", "test.zip", "http://example.com/test.zip")
+                await _download_dataset("US-TEST", "AmeriFlux", "test.zip", "http://amfcdn-dev.lbl.gov/test.zip")
 
     @pytest.mark.asyncio
     async def test_download_failure_500(self):
@@ -247,7 +249,7 @@ class TestDownloadDataset:
             mock_download_file.side_effect = PluginError("icos", "HTTP 500 Internal Server Error")
 
             with pytest.raises(FLUXNETShuttleError, match="Failed to download"):
-                await _download_dataset("FI-HYY", "ICOS", "test.zip", "http://example.com/test.zip")
+                await _download_dataset("FI-HYY", "ICOS", "test.zip", "http://amfcdn-dev.lbl.gov/test.zip")
 
     @pytest.mark.asyncio
     async def test_file_writing(self):
@@ -264,7 +266,7 @@ class TestDownloadDataset:
             patch.object(AmeriFluxPlugin, "download_file", side_effect=mock_download_file) as mock_download_file,
             patch("builtins.open", mock_open()) as mock_file,
         ):
-            await _download_dataset("US-TEST", "AmeriFlux", "output.zip", "http://example.com/file.zip")
+            await _download_dataset("US-TEST", "AmeriFlux", "output.zip", "http://amfcdn-dev.lbl.gov/file.zip")
 
             # Verify file was opened for writing
             mock_file.assert_called_once_with("./output.zip", "wb")
@@ -282,7 +284,7 @@ class TestDownloadDataset:
             mock_download_file.side_effect = Exception("Network error")
 
             with pytest.raises(FLUXNETShuttleError, match="Failed to download"):
-                await _download_dataset("US-TEST", "AmeriFlux", "test.zip", "http://example.com/test.zip")
+                await _download_dataset("US-TEST", "AmeriFlux", "test.zip", "http://amfcdn-dev.lbl.gov/test.zip")
 
     @pytest.mark.asyncio
     async def test_file_overwrite_warning(self):
@@ -306,7 +308,7 @@ class TestDownloadDataset:
             # Download to the same location
             with patch("fluxnet_shuttle.shuttle._log") as mock_log:
                 result = await _download_dataset(
-                    "US-TEST", "AmeriFlux", "existing.zip", "http://example.com/test.zip", tmpdir
+                    "US-TEST", "AmeriFlux", "existing.zip", "http://amfcdn-dev.lbl.gov/test.zip", tmpdir
                 )
 
                 # Check that warning was logged
@@ -327,7 +329,7 @@ class TestDownloadDataset:
                 FLUXNETShuttleError,
                 match="Failed to download UnknownHub file for site US-TEST.*Data hub 'unknownhub' not configured",
             ):
-                await _download_dataset("US-TEST", "UnknownHub", "test.zip", "http://example.com/test.zip")
+                await _download_dataset("US-TEST", "UnknownHub", "test.zip", "http://amfcdn-dev.lbl.gov/test.zip")
 
     @pytest.mark.asyncio
     async def test_download_with_user_info_kwargs(self):
@@ -346,14 +348,14 @@ class TestDownloadDataset:
             user_info = {
                 "ameriflux": {
                     "user_name": "Test User",
-                    "user_email": "test@example.com",
+                    "user_email": "test@amfcdn-dev.lbl.gov",
                     "intended_use": 1,
                     "description": "Test",
                 }
             }
 
             result = await _download_dataset(
-                "US-TEST", "ameriflux", "test.zip", "http://example.com/test.zip", user_info=user_info
+                "US-TEST", "ameriflux", "test.zip", "http://amfcdn-dev.lbl.gov/test.zip", user_info=user_info
             )
 
             # Verify plugin's download_file was called with user_info in kwargs
@@ -389,14 +391,14 @@ class TestFluxnetShuttleDownload:
             async for chunk in shuttle.download_dataset(
                 site_id="US-Ha1",
                 data_hub="ameriflux",
-                download_link="https://example.com/test.zip",
+                download_link="https://amfcdn-dev.lbl.gov/test.zip",
                 filename="test.zip",
             ):
                 chunks.append(chunk)
 
             assert chunks == [b"test data"]
             mock_download_file.assert_called_once_with(
-                site_id="US-Ha1", download_link="https://example.com/test.zip", filename="test.zip"
+                site_id="US-Ha1", download_link="https://amfcdn-dev.lbl.gov/test.zip", filename="test.zip"
             )
 
     @pytest.mark.asyncio
@@ -409,7 +411,7 @@ class TestFluxnetShuttleDownload:
         # Test with invalid data hub
         with pytest.raises(ValueError, match="Data hub 'invalidhub' not configured"):
             async for _ in shuttle.download_dataset(
-                site_id="US-TEST", data_hub="invalidhub", download_link="https://example.com/test.zip"
+                site_id="US-TEST", data_hub="invalidhub", download_link="https://amfcdn-dev.lbl.gov/test.zip"
             ):
                 pass  # Should not reach here
 
@@ -429,7 +431,7 @@ class TestFluxnetShuttleDownload:
 
             with pytest.raises(Exception, match="Download failed"):
                 async for _ in shuttle.download_dataset(
-                    site_id="US-Ha1", data_hub="ameriflux", download_link="https://example.com/test.zip"
+                    site_id="US-Ha1", data_hub="ameriflux", download_link="https://amfcdn-dev.lbl.gov/test.zip"
                 ):
                     pass  # Should not reach here
 
@@ -449,7 +451,7 @@ class TestFluxnetShuttleDownload:
 
             with pytest.raises(Exception, match="Download failed"):
                 async for _ in shuttle.download_dataset(
-                    site_id="US-Ha1", data_hub="ameriflux", download_link="https://example.com/test.zip"
+                    site_id="US-Ha1", data_hub="ameriflux", download_link="https://amfcdn-dev.lbl.gov/test.zip"
                 ):
                     pass  # Should not reach here
 
@@ -472,7 +474,7 @@ class TestFluxnetShuttleDownload:
         with patch.object(shuttle, "_get_plugin_instance", return_value=NoDownloadPlugin()):
             with pytest.raises(AttributeError, match="does not have 'download_file' method"):
                 async for _ in shuttle.download_dataset(
-                    site_id="US-Ha1", data_hub="ameriflux", download_link="https://example.com/test.zip"
+                    site_id="US-Ha1", data_hub="ameriflux", download_link="https://amfcdn-dev.lbl.gov/test.zip"
                 ):
                     pass  # Should not reach here
 
@@ -487,8 +489,8 @@ class TestDownload:
         snapshot_file = tmp_path / "snapshot.csv"
         snapshot_file.write_text(
             "data_hub,site_id,first_year,last_year,download_link,fluxnet_product_name\n"
-            "AmeriFlux,US-Ha1,2000,2020,https://example.com/US-Ha1.zip,US-Ha1.zip\n"
-            "AmeriFlux,US-MMS,2005,2021,https://example.com/US-MMS.zip,US-MMS.zip\n"
+            "AmeriFlux,US-Ha1,2000,2020,https://amfcdn-dev.lbl.gov/US-Ha1.zip,US-Ha1.zip\n"
+            "AmeriFlux,US-MMS,2005,2021,https://amfcdn-dev.lbl.gov/US-MMS.zip,US-MMS.zip\n"
         )
 
         # Mock the _download_dataset function to return coroutines
@@ -526,7 +528,7 @@ class TestDownload:
         "builtins.open",
         mock_open(
             read_data="site_id,data_hub,download_link,fluxnet_product_name\n"
-            "US-TEST,AmeriFlux,http://example.com/test.zip,test.zip\n"
+            "US-TEST,AmeriFlux,http://amfcdn-dev.lbl.gov/test.zip,test.zip\n"
         ),
     )
     async def test_download_ameriflux_site_success(self, mock_exists, mock_download):
@@ -545,7 +547,7 @@ class TestDownload:
             site_id="US-TEST",
             data_hub="AmeriFlux",
             filename="test.zip",
-            download_link="http://example.com/test.zip",
+            download_link="http://amfcdn-dev.lbl.gov/test.zip",
             output_dir=".",
         )
 
@@ -556,7 +558,7 @@ class TestDownload:
         "builtins.open",
         mock_open(
             read_data="site_id,data_hub,download_link,fluxnet_product_name\n"
-            "FI-HYY,ICOS,http://example.com/test.zip,test.zip\n"
+            "FI-HYY,ICOS,http://amfcdn-dev.lbl.gov/test.zip,test.zip\n"
         ),
     )
     async def test_download_icos_site_success(self, mock_exists, mock_download):
@@ -575,7 +577,7 @@ class TestDownload:
             site_id="FI-HYY",
             data_hub="ICOS",
             filename="test.zip",
-            download_link="http://example.com/test.zip",
+            download_link="http://amfcdn-dev.lbl.gov/test.zip",
             output_dir=".",
         )
 
@@ -586,7 +588,7 @@ class TestDownload:
         "builtins.open",
         mock_open(
             read_data="site_id,data_hub,download_link,fluxnet_product_name\n"
-            "US-TEST,AmeriFlux,http://example.com/file.zip?=fluxnetshuttle,file.zip\n"
+            "US-TEST,AmeriFlux,http://amfcdn-dev.lbl.gov/file.zip?=fluxnetshuttle,file.zip\n"
         ),
     )
     async def test_download_with_query_params_in_url(self, mock_exists, mock_download):
@@ -606,7 +608,7 @@ class TestDownload:
             site_id="US-TEST",
             data_hub="AmeriFlux",
             filename="file.zip",
-            download_link="http://example.com/file.zip?=fluxnetshuttle",
+            download_link="http://amfcdn-dev.lbl.gov/file.zip?=fluxnetshuttle",
             output_dir=".",
         )
 
@@ -614,7 +616,9 @@ class TestDownload:
     @patch("os.path.exists")
     @patch(
         "builtins.open",
-        mock_open(read_data="site_id,data_hub,download_link\n" "US-TEST,AmeriFlux,http://example.com/test.zip\n"),
+        mock_open(
+            read_data="site_id,data_hub,download_link\n" "US-TEST,AmeriFlux,http://amfcdn-dev.lbl.gov/test.zip\n"
+        ),
     )
     async def test_download_site_not_in_snapshot_file_raises_error(self, mock_exists):
         """Test that download raises error when site not in snapshot file."""
@@ -629,7 +633,7 @@ class TestDownload:
         # Create temporary CSV file
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
             tmp_file.write("site_id,data_hub,download_link\n")
-            tmp_file.write("US-Ha1,AmeriFlux,http://example.com/test.zip\n")
+            tmp_file.write("US-Ha1,AmeriFlux,http://amfcdn-dev.lbl.gov/test.zip\n")
             temp_filename = tmp_file.name
 
         try:
@@ -647,7 +651,7 @@ class TestDownload:
         "builtins.open",
         mock_open(
             read_data="site_id,data_hub,download_link,fluxnet_product_name\n"
-            "US-TEST,ameriflux,http://example.com/test.zip,test.zip\n"
+            "US-TEST,ameriflux,http://amfcdn-dev.lbl.gov/test.zip,test.zip\n"
         ),
     )
     async def test_download_with_user_info(self, mock_exists, mock_download):
@@ -663,7 +667,7 @@ class TestDownload:
         user_info = {
             "ameriflux": {
                 "user_name": "Test User",
-                "user_email": "test@example.com",
+                "user_email": "test@amfcdn-dev.lbl.gov",
                 "intended_use": 1,
                 "description": "Test download",
             }
@@ -682,7 +686,9 @@ class TestDownload:
     @patch("os.path.exists")
     @patch(
         "builtins.open",
-        mock_open(read_data="site_id,data_hub,download_link\n" "US-TEST,ameriflux,http://example.com/test.zip\n"),
+        mock_open(
+            read_data="site_id,data_hub,download_link\n" "US-TEST,ameriflux,http://amfcdn-dev.lbl.gov/test.zip\n"
+        ),
     )
     async def test_download_missing_filename_skips_site(self, mock_exists, caplog):
         """Test download skips sites with missing fluxnet_product_name."""
@@ -764,7 +770,7 @@ class TestListall:
                 product_data=MagicMock(
                     first_year=2000,
                     last_year=2020,
-                    download_link="http://example.com/test.zip",
+                    download_link="http://amfcdn-dev.lbl.gov/test.zip",
                     product_citation="Test citation",
                     product_id="test-id",
                     oneflux_code_version="v1",
@@ -772,7 +778,7 @@ class TestListall:
                     model_dump=lambda: {
                         "first_year": 2000,
                         "last_year": 2020,
-                        "download_link": "http://example.com/test.zip",
+                        "download_link": "http://amfcdn-dev.lbl.gov/test.zip",
                         "product_citation": "Test citation",
                         "product_id": "test-id",
                         "oneflux_code_version": "v1",
@@ -802,7 +808,7 @@ class TestListall:
                 product_data=MagicMock(
                     first_year=2005,
                     last_year=2018,
-                    download_link="http://example.com/icos.zip",
+                    download_link="http://amfcdn-dev.lbl.gov/icos.zip",
                     product_citation="ICOS citation",
                     product_id="icos-id",
                     oneflux_code_version="v2",
@@ -810,7 +816,7 @@ class TestListall:
                     model_dump=lambda: {
                         "first_year": 2005,
                         "last_year": 2018,
-                        "download_link": "http://example.com/icos.zip",
+                        "download_link": "http://amfcdn-dev.lbl.gov/icos.zip",
                         "product_citation": "ICOS citation",
                         "product_id": "icos-id",
                         "oneflux_code_version": "v2",


### PR DESCRIPTION
DataHubConfig now stores plugin-specific settings (base_url, api_url, etc.) that are forwarded to plugins via self.config. Plugins read URLs from config with fallback to existing constants. load_from_file merges override settings with defaults so users can override only the keys they need for dev/production deployments.

Refs: #8