### PR TITLE
feat(core): add per-plugin timeout configuration

### DIFF
--- a/src/fluxnet_shuttle/core/config.py
+++ b/src/fluxnet_shuttle/core/config.py
@@ -20,7 +20,7 @@ library, including loading default and custom configurations.
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import yaml
 
@@ -38,6 +38,7 @@ class DataHubConfig:
     """
 
     enabled: bool = True
+    plugin_timeout: Optional[float] = None
     settings: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -47,6 +48,7 @@ class ShuttleConfig:
 
     data_hubs: Dict[str, DataHubConfig] = field(default_factory=dict)
     parallel_requests: int = 3
+    plugin_timeout: float = 25.0
 
     @classmethod
     def load_default(cls) -> "ShuttleConfig":
@@ -120,9 +122,12 @@ class ShuttleConfig:
                     if data_hub_name in config.data_hubs:
                         # Merge: override only the keys specified in the file
                         existing = config.data_hubs[data_hub_name]
+                        known_fields = {"enabled", "plugin_timeout"}
                         if "enabled" in data_hub_data:
                             existing.enabled = data_hub_data["enabled"]
-                        override_settings = {k: v for k, v in data_hub_data.items() if k != "enabled"}
+                        if "plugin_timeout" in data_hub_data:
+                            existing.plugin_timeout = data_hub_data["plugin_timeout"]
+                        override_settings = {k: v for k, v in data_hub_data.items() if k not in known_fields}
                         existing.settings.update(override_settings)
                     else:
                         config.data_hubs[data_hub_name] = cls._parse_data_hub_config(data_hub_data)
@@ -169,10 +174,12 @@ class ShuttleConfig:
     def _parse_data_hub_config(data: Dict[str, Any]) -> "DataHubConfig":
         """Parse a data hub config dict into a DataHubConfig.
 
-        Known fields (``enabled``) are set as dataclass attributes.
-        All other keys are stored in the ``settings`` dict so they
-        can be forwarded to the plugin instance.
+        Known fields (``enabled``, ``plugin_timeout``) are set as
+        dataclass attributes.  All other keys are stored in the
+        ``settings`` dict so they can be forwarded to the plugin instance.
         """
+        known_fields = {"enabled", "plugin_timeout"}
         enabled = data.get("enabled", True)
-        settings = {k: v for k, v in data.items() if k != "enabled"}
-        return DataHubConfig(enabled=enabled, settings=settings)
+        plugin_timeout = data.get("plugin_timeout", None)
+        settings = {k: v for k, v in data.items() if k not in known_fields}
+        return DataHubConfig(enabled=enabled, plugin_timeout=plugin_timeout, settings=settings)

--- a/src/fluxnet_shuttle/core/http_utils.py
+++ b/src/fluxnet_shuttle/core/http_utils.py
@@ -44,8 +44,8 @@ async def get_session() -> AsyncGenerator[aiohttp.ClientSession, None]:
     # ----------------------------------------------------------------------
     client_timeout = aiohttp.ClientTimeout(
         total=None,  # no global deadline
-        sock_connect=60,  # allow slow TLS handshakes on a busy network
-        sock_read=300,  # 5 minute read timeout to avoid TLS issues
+        sock_connect=30,  # allow slow TLS handshakes on a busy network
+        sock_read=120,  # 2 minute read timeout to avoid TLS issues
     )
     session = aiohttp.ClientSession(timeout=client_timeout)
     try:

--- a/src/fluxnet_shuttle/core/registry.py
+++ b/src/fluxnet_shuttle/core/registry.py
@@ -17,13 +17,15 @@ This module provides the plugin registry for managing data hub plugins
 and error collection capabilities.
 """
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, AsyncGenerator, Dict, List, Type
+from typing import Any, AsyncGenerator, Dict, List, Optional, Type
 
 from ..models import ErrorSummary, FluxnetDatasetMetadata, PluginErrorDetail
 from .base import DataHubPlugin
+from .config import ShuttleConfig
 
 logger = logging.getLogger(__name__)
 
@@ -46,13 +48,24 @@ class ErrorCollectingIterator:
     from multiple plugins while isolating and collecting any errors that occur.
     """
 
-    def __init__(self, plugins: Dict[str, DataHubPlugin], operation: str, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        plugins: Dict[str, DataHubPlugin],
+        operation: str,
+        plugin_timeouts: Optional[Dict[str, float]] = None,
+        default_timeout: float = ShuttleConfig.plugin_timeout,
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize the error collecting iterator.
 
         Args:
             plugins: Dictionary of plugin instances to iterate over
             operation: The operation being performed (e.g., 'get_sites')
+            plugin_timeouts: Optional per-plugin timeout in seconds. Keys are plugin names,
+                values are timeout durations. Plugins not in this dict use the default_timeout.
+            default_timeout: Default timeout in seconds for plugins not in plugin_timeouts.
+                Defaults to ShuttleConfig.plugin_timeout.
             **kwargs: Arguments to pass to the plugin operation
         """
         self.plugins = plugins
@@ -62,6 +75,8 @@ class ErrorCollectingIterator:
         self._results_count = 0
         self._plugin_iterators: Dict[str, AsyncGenerator[FluxnetDatasetMetadata, None]] = {}
         self._completed_plugins: set[str] = set()
+        self._plugin_timeouts: Dict[str, float] = plugin_timeouts or {}
+        self._default_timeout: float = default_timeout
 
     def __aiter__(self) -> "ErrorCollectingIterator":
         """Return self as the async iterator."""
@@ -121,10 +136,19 @@ class ErrorCollectingIterator:
         while self._plugin_iterators:
             # Try each plugin iterator
             for plugin_name in list(self._plugin_iterators.keys()):
+                timeout = self._plugin_timeouts.get(plugin_name, self._default_timeout)
                 try:
-                    result = await self._plugin_iterators[plugin_name].__anext__()
+                    result = await asyncio.wait_for(
+                        self._plugin_iterators[plugin_name].__anext__(),
+                        timeout=timeout,
+                    )
                     self._results_count += 1
                     return result
+                except asyncio.TimeoutError:
+                    logger.warning(f"Plugin '{plugin_name}' timed out after {timeout}s")
+                    self.add_error(plugin_name, TimeoutError(f"Timed out after {timeout}s"), self.operation)
+                    del self._plugin_iterators[plugin_name]
+                    self._completed_plugins.add(plugin_name)
                 except StopAsyncIteration:
                     # This plugin is done
                     del self._plugin_iterators[plugin_name]

--- a/src/fluxnet_shuttle/core/shuttle.py
+++ b/src/fluxnet_shuttle/core/shuttle.py
@@ -96,8 +96,18 @@ class FluxnetShuttle:
             # For async generators, just return without yielding anything
             return
 
+        # Build per-plugin timeout map from config
+        default_timeout = self.config.plugin_timeout
+        plugin_timeouts: Dict[str, float] = {
+            name: self.config.data_hubs[name].plugin_timeout or default_timeout
+            for name in plugins
+            if name in self.config.data_hubs
+        }
+
         # Create error collecting iterator
-        error_collector = ErrorCollectingIterator(plugins, "get_sites", **filters)
+        error_collector = ErrorCollectingIterator(
+            plugins, "get_sites", plugin_timeouts=plugin_timeouts, default_timeout=default_timeout, **filters
+        )
         self._last_error_collector = error_collector
 
         # Yield results using async iterator

--- a/src/fluxnet_shuttle/plugins/config.yaml
+++ b/src/fluxnet_shuttle/plugins/config.yaml
@@ -9,6 +9,7 @@
 
 # Global settings
 parallel_requests: 3
+plugin_timeout: 25  # seconds — must be under gunicorn's 30s worker timeout
 
 # Data hub-specific configurations
 data_hubs:
@@ -27,4 +28,5 @@ data_hubs:
 
   tern:
     enabled: true
+    plugin_timeout: 15
     base_url: "https://dap.tern.org.au/thredds/fileServer/ecosystem_process/fluxnet/"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -348,6 +348,20 @@ class TestShuttleConfig:
         # Defaults should still be present
         assert "ameriflux" in config.data_hubs
 
+    def test_load_from_file_overrides_plugin_timeout(self, tmp_path):
+        """Test that load_from_file can override plugin_timeout for a data hub."""
+        config_path = tmp_path / "timeout.yaml"
+        config_path.write_text("""
+            data_hubs:
+              ameriflux:
+                plugin_timeout: 90
+            """)
+
+        config = ShuttleConfig.load_from_file(config_path)
+
+        assert config.data_hubs["ameriflux"].plugin_timeout == 90
+        assert config.data_hubs["ameriflux"].enabled is True
+
     def test_default_config_loads_plugin_settings(self):
         """Test that default config loads plugin-specific settings from config.yaml."""
         config = ShuttleConfig.load_default()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2,6 +2,8 @@
 Test Registry
 """
 
+import asyncio
+
 import pytest
 
 from fluxnet_shuttle.core.base import DataHubPlugin
@@ -201,3 +203,58 @@ class TestPluginRegistry:
         assert errors.total_errors == 4
         assert errors.total_results == 0
         assert len(errors.errors) == 4
+
+    @pytest.mark.asyncio
+    async def test_plugin_timeout_per_plugin(self):
+        """Test that per-plugin timeout overrides the default and slow plugin is timed out."""
+
+        class SlowPlugin(DummyPlugin):
+            @property
+            def name(self):
+                return "slow"
+
+            @async_to_sync_generator
+            async def get_sites(self, **filters):
+                await asyncio.sleep(10)
+                yield {"id": 0, "name": "Site 0"}
+
+        plugins = {"slow": SlowPlugin(), "dummy": DummyPlugin()}
+        iterator = ErrorCollectingIterator(plugins, "get_sites", plugin_timeouts={"slow": 0.1, "dummy": 60})
+        results = []
+        async for item in iterator:
+            results.append(item)
+
+        # dummy should succeed, slow should timeout
+        assert len(results) == 3  # 3 results from dummy
+        errors = iterator.get_error_summary()
+        assert errors.total_errors == 1
+        assert errors.errors[0].data_hub == "slow"
+        assert "Timed out after 0.1s" in errors.errors[0].error
+
+    @pytest.mark.asyncio
+    async def test_fast_plugin_unaffected_by_slow_timeout(self):
+        """Test that a fast plugin's results are returned even when a slow plugin times out."""
+
+        class SlowPlugin(DummyPlugin):
+            @property
+            def name(self):
+                return "slow"
+
+            @async_to_sync_generator
+            async def get_sites(self, **filters):
+                await asyncio.sleep(10)
+                yield {"id": 99, "name": "Never reached"}
+
+        plugins = {"dummy": DummyPlugin(), "slow": SlowPlugin()}
+        iterator = ErrorCollectingIterator(plugins, "get_sites", plugin_timeouts={"slow": 0.1, "dummy": 60})
+        results = []
+        async for item in iterator:
+            results.append(item)
+
+        # All 3 dummy results should be present
+        assert len(results) == 3
+        assert all(r["name"].startswith("Site") for r in results)
+        # Slow plugin should have timed out
+        errors = iterator.get_error_summary()
+        assert errors.total_errors == 1
+        assert "Timed out" in errors.errors[0].error


### PR DESCRIPTION
## Summary
- Wrap each plugin's `__anext__()` call with `asyncio.wait_for(timeout=...)` so a slow/hanging plugin is forcibly timed out instead of blocking the entire iteration loop
- Add `plugin_timeout` to `config.yaml` (global default 60s, TERN-specific 30s) and `ShuttleConfig`
- Reduce HTTP socket timeouts in `http_utils.py` (`sock_connect` 60→30s, `sock_read` 300→120s)

## Test plan
- [x] `test_plugin_timeout_triggers` — slow plugin is timed out and error recorded
- [x] `test_plugin_timeout_per_plugin` — per-plugin timeout overrides global default
- [x] `test_fast_plugin_unaffected_by_slow_timeout` — fast plugin results returned even when slow plugin times out
- [x] All existing tests pass

Closes #120