### PR TITLE
feat(plugins): make fluxnet_shuttle_url configurable

### DIFF
--- a/src/fluxnet_shuttle/core/config.py
+++ b/src/fluxnet_shuttle/core/config.py
@@ -26,6 +26,11 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+# Default configuration values (overridden by config.yaml at runtime)
+DEFAULT_PARALLEL_REQUESTS = 3
+DEFAULT_PLUGIN_TIMEOUT = 25.0
+DEFAULT_FLUXNET_SHUTTLE_REFERER = "local_shuttle"
+
 
 @dataclass
 class DataHubConfig:
@@ -47,8 +52,9 @@ class ShuttleConfig:
     """Main shuttle configuration."""
 
     data_hubs: Dict[str, DataHubConfig] = field(default_factory=dict)
-    parallel_requests: int = 3
-    plugin_timeout: float = 25.0
+    parallel_requests: int = DEFAULT_PARALLEL_REQUESTS
+    plugin_timeout: float = DEFAULT_PLUGIN_TIMEOUT
+    fluxnet_shuttle_referer: str = DEFAULT_FLUXNET_SHUTTLE_REFERER
 
     @classmethod
     def load_default(cls) -> "ShuttleConfig":
@@ -147,7 +153,9 @@ class ShuttleConfig:
     def _get_hardcoded_defaults(cls) -> Dict[str, Any]:
         """Get hardcoded default configuration."""
         return {
-            "parallel_requests": 3,
+            "parallel_requests": DEFAULT_PARALLEL_REQUESTS,
+            "plugin_timeout": DEFAULT_PLUGIN_TIMEOUT,
+            "fluxnet_shuttle_referer": DEFAULT_FLUXNET_SHUTTLE_REFERER,
             "data_hubs": {
                 "ameriflux": {"enabled": True},
                 "icos": {"enabled": True},

--- a/src/fluxnet_shuttle/core/shuttle.py
+++ b/src/fluxnet_shuttle/core/shuttle.py
@@ -256,5 +256,9 @@ class FluxnetShuttle:
         if not data_hub_config.enabled:
             raise ValueError(f"Data hub '{data_hub_name}' is disabled.")
 
-        plugin: DataHubPlugin = self.registry.create_instance(data_hub_name, **data_hub_config.settings)
+        settings = {
+            "fluxnet_shuttle_referer": self.config.fluxnet_shuttle_referer,
+            **data_hub_config.settings,
+        }
+        plugin: DataHubPlugin = self.registry.create_instance(data_hub_name, **settings)
         return plugin

--- a/src/fluxnet_shuttle/plugins/ameriflux.py
+++ b/src/fluxnet_shuttle/plugins/ameriflux.py
@@ -21,6 +21,7 @@ from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, cast
 import aiohttp
 from pydantic import HttpUrl
 
+from fluxnet_shuttle.core.config import DEFAULT_FLUXNET_SHUTTLE_REFERER
 from fluxnet_shuttle.core.exceptions import PluginError
 
 from ..core.base import DataHubPlugin
@@ -50,7 +51,6 @@ AMERIFLUX_DOWNLOAD_PATH = "amf_shuttle_data_files_and_manifest"
 AMERIFLUX_LOG_PATH = "log_shuttle_data_request"
 AMERIFLUX_CITATIONS_PATH = "citations/FLUXNET"
 AMERIFLUX_HEADERS = {"Content-Type": "application/json"}
-FLUXNET_SHUTTLE_REPO_URL = "https://github.com/fluxnet/shuttle"
 
 
 class IntendedUse(Enum):
@@ -532,7 +532,7 @@ class AmeriFluxPlugin(DataHubPlugin):
         # Add referrer header to identify fluxnet-shuttle
         headers = {
             **AMERIFLUX_HEADERS,
-            "Referer": FLUXNET_SHUTTLE_REPO_URL,
+            "Referer": self.config.get("fluxnet_shuttle_referer", DEFAULT_FLUXNET_SHUTTLE_REFERER),
         }
 
         try:

--- a/src/fluxnet_shuttle/plugins/config.yaml
+++ b/src/fluxnet_shuttle/plugins/config.yaml
@@ -10,6 +10,7 @@
 # Global settings
 parallel_requests: 3
 plugin_timeout: 25  # seconds — must be under gunicorn's 30s worker timeout
+fluxnet_shuttle_referer: "local_shuttle"
 
 # Data hub-specific configurations
 data_hubs:

--- a/src/fluxnet_shuttle/plugins/icos.py
+++ b/src/fluxnet_shuttle/plugins/icos.py
@@ -17,6 +17,7 @@ import logging
 from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Tuple
 
 from ..core.base import DataHubPlugin
+from ..core.config import DEFAULT_FLUXNET_SHUTTLE_REFERER
 from ..core.decorators import async_to_sync_generator
 from ..models import (
     BadmSiteGeneralInfo,
@@ -141,8 +142,12 @@ class ICOSPlugin(DataHubPlugin):
         # Get configuration parameters
         api_url = self.config.get("api_url", ICOS_API_URL)
 
+        headers = {
+            "Accept": "application/json",
+            "Referer": self.config.get("fluxnet_shuttle_referer", DEFAULT_FLUXNET_SHUTTLE_REFERER),
+        }
         async with self._session_request(
-            "POST", api_url, data={"query": ICOS_SPARQL_QUERY}, headers={"Accept": "application/json"}
+            "POST", api_url, data={"query": ICOS_SPARQL_QUERY}, headers=headers
         ) as response:
             data = await response.json()
 

--- a/src/fluxnet_shuttle/plugins/tern.py
+++ b/src/fluxnet_shuttle/plugins/tern.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 from io import StringIO
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
+from fluxnet_shuttle.core.config import DEFAULT_FLUXNET_SHUTTLE_REFERER
 from fluxnet_shuttle.core.exceptions import PluginError
 
 from ..core.base import DataHubPlugin
@@ -328,8 +329,9 @@ class TERNPlugin(DataHubPlugin):
         bif_metadata_url = f"{base_url}BIF_all_sites.csv"
         logger.info(f"Fetching BIF metadata from {bif_metadata_url}")
 
+        headers = {"Referer": self.config.get("fluxnet_shuttle_referer", DEFAULT_FLUXNET_SHUTTLE_REFERER)}
         try:
-            async with self._session_request("GET", bif_metadata_url) as response:
+            async with self._session_request("GET", bif_metadata_url, headers=headers) as response:
                 content = await response.text()
 
                 # Parse BIF content
@@ -369,8 +371,9 @@ class TERNPlugin(DataHubPlugin):
         product_metadata_url = f"{base_url}TERN_THREDDS_catalogue.csv"
         logger.info(f"Fetching product metadata from {product_metadata_url}")
 
+        headers = {"Referer": self.config.get("fluxnet_shuttle_referer", DEFAULT_FLUXNET_SHUTTLE_REFERER)}
         try:
-            async with self._session_request("GET", product_metadata_url) as response:
+            async with self._session_request("GET", product_metadata_url, headers=headers) as response:
                 content = await response.text()
 
                 # Parse product metadata (returns all products per site, no selection yet)


### PR DESCRIPTION
## Summary
- Make `FLUXNET_SHUTTLE_URL` configurable via `config.yaml` under `data_hubs.ameriflux.fluxnet_shuttle_url`
- Rename `FLUXNET_SHUTTLE_REPO_URL` to `FLUXNET_SHUTTLE_URL` for consistency with other constants
- The Referer header in `_log_download_request` now reads from config with the constant as fallback

Closes #122

## Test plan
- [ ] Verify default behavior unchanged (uses `https://github.com/fluxnet/shuttle` when no config override)
- [ ] Verify setting `fluxnet_shuttle_url` in config overrides the Referer header