### PR TITLE
fix(core): batch concurrent downloads to prevent too many open files

### DIFF
--- a/src/fluxnet_shuttle/core/config.py
+++ b/src/fluxnet_shuttle/core/config.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 # Default configuration values (overridden by config.yaml at runtime)
 DEFAULT_PARALLEL_REQUESTS = 3
+DEFAULT_DOWNLOAD_BATCH_SIZE = 10
 DEFAULT_FLUXNET_SHUTTLE_REFERER = "local_shuttle"
 
 # Default HTTP timeout values (used when config.yaml omits http_timeouts)
@@ -65,6 +66,7 @@ class ShuttleConfig:
 
     data_hubs: Dict[str, DataHubConfig] = field(default_factory=dict)
     parallel_requests: int = DEFAULT_PARALLEL_REQUESTS
+    download_batch_size: int = DEFAULT_DOWNLOAD_BATCH_SIZE
     fluxnet_shuttle_referer: str = DEFAULT_FLUXNET_SHUTTLE_REFERER
     http_timeouts: HttpTimeoutConfig = field(default_factory=HttpTimeoutConfig)
 
@@ -180,6 +182,7 @@ class ShuttleConfig:
         """Get hardcoded default configuration."""
         return {
             "parallel_requests": DEFAULT_PARALLEL_REQUESTS,
+            "download_batch_size": DEFAULT_DOWNLOAD_BATCH_SIZE,
             "fluxnet_shuttle_referer": DEFAULT_FLUXNET_SHUTTLE_REFERER,
             "data_hubs": {
                 "ameriflux": {"enabled": True},

--- a/src/fluxnet_shuttle/plugins/config.yaml
+++ b/src/fluxnet_shuttle/plugins/config.yaml
@@ -9,6 +9,7 @@
 
 # Global settings
 parallel_requests: 3
+download_batch_size: 10  # number of concurrent downloads per batch
 fluxnet_shuttle_referer: "local_shuttle"
 
 # HTTP timeout settings (applied to all plugins)

--- a/src/fluxnet_shuttle/shuttle.py
+++ b/src/fluxnet_shuttle/shuttle.py
@@ -57,6 +57,7 @@ from urllib.parse import unquote, urlparse
 import aiofiles
 
 from fluxnet_shuttle import FLUXNETShuttleError
+from fluxnet_shuttle.core.config import ShuttleConfig
 from fluxnet_shuttle.core.decorators import async_to_sync
 from fluxnet_shuttle.core.shuttle import FluxnetShuttle
 
@@ -311,25 +312,31 @@ async def download(
         _log.info("No valid downloads found after processing snapshot file.")
         return []
 
-    tasks = [
-        _download_dataset(
-            site_id=job["site_id"],
-            data_hub=job["data_hub"],
-            filename=job["filename"],
-            download_link=job["download_link"],
-            output_dir=output_dir,
-            **kwargs,
-        )
-        for job in download_jobs
-    ]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
+    batch_size = ShuttleConfig.load_default().download_batch_size
+    _log.info(f"Downloading in batches of {batch_size}")
 
     downloaded_filenames: list[str] = []
-    for job, result in zip(download_jobs, results):
-        if isinstance(result, BaseException):
-            _log.error(f"Failed to download {job['filename']} for site {job['site_id']}: {result}")
-        else:
-            downloaded_filenames.append(result)
+    for i in range(0, len(download_jobs), batch_size):
+        batch = download_jobs[i : i + batch_size]
+        tasks = [
+            _download_dataset(
+                site_id=job["site_id"],
+                data_hub=job["data_hub"],
+                filename=job["filename"],
+                download_link=job["download_link"],
+                output_dir=output_dir,
+                **kwargs,
+            )
+            for job in batch
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for job, result in zip(batch, results):
+            if isinstance(result, BaseException):
+                _log.error(f"Failed to download {job['filename']} for site {job['site_id']}: {result}")
+            else:
+                downloaded_filenames.append(result)
+        batch_num = i // batch_size + 1
+        _log.info(f"Batch {batch_num} complete: {len(downloaded_filenames)} / {len(download_jobs)} downloaded so far")
 
     _log.info(f"Downloaded data for {len(downloaded_filenames)}/{len(download_jobs)} sites")
     return downloaded_filenames

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -287,6 +287,7 @@ class TestShuttleConfig:
         config = ShuttleConfig._create_default_config()
 
         assert config.parallel_requests == 3  # Hardcoded default
+        assert config.download_batch_size == 10  # Hardcoded default
         assert "ameriflux" in config.data_hubs
         assert "icos" in config.data_hubs
         assert "tern" in config.data_hubs
@@ -432,6 +433,20 @@ class TestShuttleConfig:
         assert config.http_timeouts.total == DEFAULT_HTTP_TIMEOUT_TOTAL
         assert config.http_timeouts.sock_connect == DEFAULT_HTTP_SOCK_CONNECT
         assert config.http_timeouts.sock_read == DEFAULT_HTTP_SOCK_READ
+
+    def test_load_from_file_custom_download_batch_size(self, tmp_path):
+        """Test that a custom download_batch_size in config.yaml is read properly."""
+        config_path = tmp_path / "custom_batch.yaml"
+        config_path.write_text("""
+            download_batch_size: 25
+            """)
+
+        config = ShuttleConfig.load_from_file(config_path)
+
+        assert config.download_batch_size == 25
+        # Other defaults should be preserved
+        assert config.parallel_requests == 3
+        assert "ameriflux" in config.data_hubs
 
     def test_default_config_loads_plugin_settings(self):
         """Test that default config loads plugin-specific settings from config.yaml."""

--- a/tests/test_shuttle.py
+++ b/tests/test_shuttle.py
@@ -734,6 +734,37 @@ class TestDownload:
         assert mock_download.call_count == 2
         assert "Failed to download US-Ha1.zip for site US-Ha1" in caplog.text
 
+    @pytest.mark.asyncio
+    async def test_download_processes_in_batches(self, tmp_path):
+        """Test that download processes sites in batches according to download_batch_size."""
+        snapshot_file = tmp_path / "snapshot.csv"
+        snapshot_file.write_text(
+            "data_hub,site_id,first_year,last_year,download_link,fluxnet_product_name\n"
+            "AmeriFlux,US-Ha1,2000,2020,https://amfcdn-dev.lbl.gov/US-Ha1.zip,US-Ha1.zip\n"
+            "AmeriFlux,US-MMS,2005,2021,https://amfcdn-dev.lbl.gov/US-MMS.zip,US-MMS.zip\n"
+            "AmeriFlux,US-UMB,2000,2020,https://amfcdn-dev.lbl.gov/US-UMB.zip,US-UMB.zip\n"
+            "AmeriFlux,US-Bar,2004,2021,https://amfcdn-dev.lbl.gov/US-Bar.zip,US-Bar.zip\n"
+            "AmeriFlux,US-Kon,2006,2020,https://amfcdn-dev.lbl.gov/US-Kon.zip,US-Kon.zip\n"
+        )
+
+        mock_cfg = MagicMock()
+        mock_cfg.download_batch_size = 2
+
+        with (
+            patch("fluxnet_shuttle.shuttle._download_dataset") as mock_download,
+            patch("fluxnet_shuttle.shuttle.ShuttleConfig.load_default", return_value=mock_cfg),
+        ):
+
+            async def mock_download_side_effect(*_args, **kwargs):
+                return kwargs.get("filename", "")
+
+            mock_download.side_effect = mock_download_side_effect
+
+            result = await download(site_ids=None, snapshot_file=str(snapshot_file), output_dir=str(tmp_path))
+
+        assert len(result) == 5
+        assert mock_download.call_count == 5
+
 
 class TestListall:
     """Test cases for the listall function."""


### PR DESCRIPTION
## Summary

- Fixes [Errno 24] Too many open files when downloading large snapshots (e.g. 652 sites)
- Introduces a `download_batch_size` config key (default: 10) in `config.yaml` to control concurrent downloads per batch
- Downloads now process in sequential batches instead of all at once via unbounded `asyncio.gather`

## Test plan

- [ ] New test `test_download_processes_in_batches` verifies batching with a small batch size across 5 sites
- [ ] Existing `TestShuttleConfig::test_default_config_creation` asserts `download_batch_size == 10`
- [ ] Full unit test suite passes on Python 3.11 / 3.12 / 3.13 with 100% coverage

Closes #140