### PR TITLE
fix(examples): remove installation cell from notebook

### DIFF
--- a/examples/fluxnet_shuttle_example.ipynb
+++ b/examples/fluxnet_shuttle_example.ipynb
@@ -28,33 +28,10 @@
     "- **ICOS**: Integrated Carbon Observation System (Europe)\n",
     "- **TERN**: Terrestrial Ecosystem Research Network (Australia)\n",
     "\n",
-    "## Requirements\n",
-    "- `fluxnet_shuttle`\n",
-    "- `pandas`\n",
-    "- `matplotlib` (for plotting)\n",
-    "- Network connection for data discovery and download"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bfe5b897",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-24T19:12:50.713512Z",
-     "iopub.status.busy": "2026-02-24T19:12:50.712932Z",
-     "iopub.status.idle": "2026-02-24T19:12:50.723461Z",
-     "shell.execute_reply": "2026-02-24T19:12:50.720800Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Install required packages\n",
-    "# Uncomment and run if packages are not already installed\n",
-    "# !pip install pandas matplotlib\n",
+    "## Installation\n",
     "\n",
-    "# For development installation of fluxnet-shuttle-lib:\n",
-    "# !pip install -e ."
+    "Before running this notebook, install the required packages by following the\n",
+    "instructions in the [README](../README.md)."
    ]
   },
   {


### PR DESCRIPTION
## Summary

- Removes the commented-out `pip install` code cell from `examples/fluxnet_shuttle_example.ipynb` (fixes #143)
- Replaces the `## Requirements` section in the intro markdown cell with an `## Installation` note that links to the README

## Motivation

The install block implied users should install packages from within the notebook and exposed a dev-install path (`pip install -e .`) that is irrelevant for regular users. Installation instructions already live in the README; duplicating them here created inconsistency and confusion.